### PR TITLE
(Feat) Implementing fiveg_n4 requirer side

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -19,7 +19,7 @@ jobs:
     uses: canonical/sdcore-github-workflows/.github/workflows/unit-test.yaml@main
 
   integration-test:
-    uses: canonical/sdcore-github-workflows/.github/workflows/integration-test.yaml@main
+    uses: canonical/sdcore-github-workflows/.github/workflows/integration-test-with-multus.yaml@main
     with:
       charm-file-name: "sdcore-nms_ubuntu-22.04-amd64.charm"
       enable-metallb: true

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -22,7 +22,6 @@ jobs:
     uses: canonical/sdcore-github-workflows/.github/workflows/integration-test-with-multus.yaml@main
     with:
       charm-file-name: "sdcore-nms_ubuntu-22.04-amd64.charm"
-      enable-metallb: true
 
   publish-charm:
     name: Publish Charm

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -15,6 +15,10 @@ jobs:
   static-analysis:
     uses: canonical/sdcore-github-workflows/.github/workflows/static-analysis.yaml@main
 
+  check-libraries:
+    uses: canonical/sdcore-github-workflows/.github/workflows/check-libraries.yaml@main
+    secrets: inherit
+
   unit-tests-with-coverage:
     uses: canonical/sdcore-github-workflows/.github/workflows/unit-test.yaml@main
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -5,10 +5,8 @@ on:
     branches:
       - main
   push:
-    branches:
-      - main
-    schedule:
-      - cron: "40 6 * * 0"
+  schedule:
+    - cron: "40 6 * * 0"
 
 jobs:
   lint-report:

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+*.idea
+.vscode/
+.coverage
+.mypy_cache/
+.tox/
+
+# Python
+**/venv/**
+*.pyc
+
+# Charmcraft
+*.charm

--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ juju deploy sdcore-nms --channel=edge --config webui-endpoint=<webui endpoint>
 
 ```bash
 juju deploy traefik-k8s --trust --config external_hostname=<your hostname> --config routing_mode=subdomain
+juju deploy sdcore-upf --channel=edge --trust
 juju integrate sdcore-nms:ingress traefik-k8s:ingress
+juju integrate sdcore-nms:fiveg_n4 sdcore-upf:fiveg_n4
 ```
 
 You should now be able to access the NMS at `https://<model name>-sdcore-nms.<your hostname>`

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -6,3 +6,9 @@ bases:
     run-on:
     - name: ubuntu
       channel: "22.04"
+
+parts:
+  charm:
+    build-packages:
+      - cargo
+      - rustc

--- a/config.yaml
+++ b/config.yaml
@@ -5,9 +5,3 @@ options:
   webui-endpoint:
     description: The URL of the SD-Core API provided by the webui service.
     type: string
-  upf-hostname:
-    type: string
-    default: "upf"
-  upf-port:
-    type: int
-    default: 8805

--- a/lib/charms/sdcore_upf/v0/fiveg_n4.py
+++ b/lib/charms/sdcore_upf/v0/fiveg_n4.py
@@ -1,0 +1,290 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Library for the `fiveg_n4` relation.
+
+This library contains the Requires and Provides classes for handling the `fiveg_n4`
+interface.
+
+The purpose of this library is to integrate a charm claiming to be able to provide
+information required to establish communication over the N4 interface with a charm
+claiming to be able to consume this information.
+
+To get started using the library, you need to fetch the library using `charmcraft`.
+
+```shell
+cd some-charm
+charmcraft fetch-lib charms.sdcore_upf.v0.fiveg_n4
+```
+
+Add the following libraries to the charm's `requirements.txt` file:
+- pydantic
+- pytest-interface-tester
+
+Charms providing the `fiveg_n4` relation should use `N4Provides`.
+Typical usage of this class would look something like:
+
+    ```python
+    ...
+    from charms.sdcore_upf.v0.fiveg_n4 import N4Provides
+    ...
+
+    class SomeProviderCharm(CharmBase):
+
+        def __init__(self, *args):
+            ...
+            self.fiveg_n4 = N4Provides(charm=self, relation_name="fiveg_n4")
+            ...
+            self.framework.observe(self.fiveg_n4.on.fiveg_n4_request, self._on_fiveg_n4_request)
+
+        def _on_fiveg_n4_request(self, event):
+            ...
+            self.fiveg_n4.publish_upf_n4_information(
+                relation_id=event.relation_id,
+                upf_hostname=hostname,
+                upf_port=n4_port,
+            )
+    ```
+
+    And a corresponding section in charm's `metadata.yaml`:
+    ```
+    provides:
+        fiveg_n4:  # Relation name
+            interface: fiveg_n4  # Relation interface
+    ```
+
+Charms that require the `fiveg_n4` relation should use `N4Requires`.
+Typical usage of this class would look something like:
+
+    ```python
+    ...
+    from charms.sdcore_upf.v0.fiveg_n4 import N4Requires
+    ...
+
+    class SomeRequirerCharm(CharmBase):
+
+        def __init__(self, *args):
+            ...
+            self.fiveg_n4 = N4Requires(charm=self, relation_name="fiveg_n4")
+            ...
+            self.framework.observe(self.upf.on.fiveg_n4_available, self._on_fiveg_n4_available)
+
+        def _on_fiveg_n4_available(self, event):
+            upf_hostname = event.upf_hostname,
+            upf_port = event.upf_port,
+            # Do something with the UPF's hostname and port
+    ```
+
+    And a corresponding section in charm's `metadata.yaml`:
+    ```
+    requires:
+        fiveg_n4:  # Relation name
+            interface: fiveg_n4  # Relation interface
+    ```
+"""
+
+import logging
+
+from interface_tester.schema_base import DataBagSchema  # type: ignore[import]
+from ops.charm import CharmBase, CharmEvents, RelationChangedEvent, RelationJoinedEvent
+from ops.framework import EventBase, EventSource, Object
+from pydantic import BaseModel, Field, ValidationError
+
+# The unique Charmhub library identifier, never change it
+LIBID = "bc6261cf77104d4fb3edfd6d4ea63149"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 2
+
+PYDEPS = ["pydantic", "pytest-interface-tester"]
+
+
+logger = logging.getLogger(__name__)
+
+"""Schemas definition for the provider and requirer sides of the `fiveg_n4` interface.
+It exposes two interfaces.schema_base.DataBagSchema subclasses called:
+- ProviderSchema
+- RequirerSchema
+Examples:
+    ProviderSchema:
+        unit: <empty>
+        app: {
+            "upf_hostname": "upf.uplane-cloud.canonical.com",
+            "upf_port": 8805
+        }
+    RequirerSchema:
+        unit: <empty>
+        app:  <empty>
+"""
+
+
+class FivegN4ProviderAppData(BaseModel):
+    """Provider app data for fiveg_n4."""
+
+    upf_hostname: str = Field(
+        description="Name of the host exposing the UPF's N4 interface.",
+        examples=["upf.uplane-cloud.canonical.com"],
+    )
+    upf_port: int = Field(
+        description="Port on which UPF's N4 interface is exposed.",
+        examples=[8805],
+    )
+
+
+class ProviderSchema(DataBagSchema):
+    """Provider schema for fiveg_n4."""
+
+    app: FivegN4ProviderAppData
+
+
+def data_matches_provider_schema(data: dict) -> bool:
+    """Returns whether data matches provider schema.
+
+    Args:
+        data (dict): Data to be validated.
+
+    Returns:
+        bool: True if data matches provider schema, False otherwise.
+    """
+    try:
+        ProviderSchema(app=data)
+        return True
+    except ValidationError as e:
+        logger.error("Invalid data: %s", e)
+        return False
+
+
+class FiveGN4RequestEvent(EventBase):
+    """Dataclass for the `fiveg_n4` request event."""
+
+    def __init__(self, handle, relation_id: int):
+        """Sets relation id."""
+        super().__init__(handle)
+        self.relation_id = relation_id
+
+    def snapshot(self) -> dict:
+        """Returns event data."""
+        return {
+            "relation_id": self.relation_id,
+        }
+
+    def restore(self, snapshot):
+        """Restores event data."""
+        self.relation_id = snapshot["relation_id"]
+
+
+class N4ProviderCharmEvents(CharmEvents):
+    """Custom events for the N4Provider."""
+
+    fiveg_n4_request = EventSource(FiveGN4RequestEvent)
+
+
+class N4Provides(Object):
+    """Class to be instantiated by provider of the `fiveg_n4`."""
+
+    on = N4ProviderCharmEvents()
+
+    def __init__(self, charm: CharmBase, relation_name: str):
+        """Observes relation joined event.
+
+        Args:
+            charm: Juju charm
+            relation_name (str): Relation name
+        """
+        self.relation_name = relation_name
+        self.charm = charm
+        super().__init__(charm, relation_name)
+        self.framework.observe(charm.on[relation_name].relation_joined, self._on_relation_joined)
+
+    def publish_upf_n4_information(
+        self, relation_id: int, upf_hostname: str, upf_n4_port: int
+    ) -> None:
+        """Sets UPF's hostname and port in the relation data.
+
+        Args:
+            relation_id (str): Relation ID
+            upf_hostname (str): UPF's hostname
+            upf_n4_port (int): Port on which UPF accepts N4 communication
+        """
+        if not data_matches_provider_schema(
+            data={"upf_hostname": upf_hostname, "upf_port": upf_n4_port}
+        ):
+            raise ValueError(f"Invalid UPF N4 data: {upf_hostname}, {upf_n4_port}")
+        relation = self.model.get_relation(
+            relation_name=self.relation_name, relation_id=relation_id
+        )
+        if not relation:
+            raise RuntimeError(f"Relation {self.relation_name} not created yet.")
+        relation.data[self.charm.app]["upf_hostname"] = upf_hostname
+        relation.data[self.charm.app]["upf_port"] = str(upf_n4_port)
+
+    def _on_relation_joined(self, event: RelationJoinedEvent) -> None:
+        """Triggered whenever a requirer charm joins the relation.
+
+        Args:
+            event (RelationJoinedEvent): Juju event
+        """
+        self.on.fiveg_n4_request.emit(relation_id=event.relation.id)
+
+
+class N4AvailableEvent(EventBase):
+    """Dataclass for the `fiveg_n4` available event."""
+
+    def __init__(self, handle, upf_hostname: str, upf_port: int):
+        """Sets UPF's hostname and port."""
+        super().__init__(handle)
+        self.upf_hostname = upf_hostname
+        self.upf_port = upf_port
+
+    def snapshot(self) -> dict:
+        """Returns event data."""
+        return {
+            "upf_hostname": self.upf_hostname,
+            "upf_port": self.upf_port,
+        }
+
+    def restore(self, snapshot):
+        """Restores event data."""
+        self.upf_hostname = snapshot["upf_hostname"]
+        self.upf_port = snapshot["upf_port"]
+
+
+class N4RequirerCharmEvents(CharmEvents):
+    """Custom events for the N4Requirer."""
+
+    fiveg_n4_available = EventSource(N4AvailableEvent)
+
+
+class N4Requires(Object):
+    """Class to be instantiated by requirer of the `fiveg_n4`."""
+
+    on = N4RequirerCharmEvents()
+
+    def __init__(self, charm: CharmBase, relation_name: str):
+        """Observes relation joined and relation changed events.
+
+        Args:
+            charm: Juju charm
+            relation_name (str): Relation name
+        """
+        self.relation_name = relation_name
+        self.charm = charm
+        super().__init__(charm, relation_name)
+        self.framework.observe(charm.on[relation_name].relation_joined, self._on_relation_changed)
+        self.framework.observe(charm.on[relation_name].relation_changed, self._on_relation_changed)
+
+    def _on_relation_changed(self, event: RelationChangedEvent) -> None:
+        """Triggered everytime there's a change in relation data.
+
+        Args:
+            event (RelationChangedEvent): Juju event
+        """
+        relation_data = event.relation.data
+        upf_hostname = relation_data[event.app].get("upf_hostname")  # type: ignore[index]
+        upf_port = relation_data[event.app].get("upf_port")  # type: ignore[index]
+        if upf_hostname and upf_port:
+            self.on.fiveg_n4_available.emit(upf_hostname=upf_hostname, upf_port=upf_port)

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -18,6 +18,9 @@ assumes:
   - k8s-api
 
 requires:
+  fiveg_n4:
+    interface: fiveg_n4
+    limit: 1
   ingress:
     interface: ingress
     limit: 1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,7 @@
+jsonschema
 jinja2
 lightkube
 lightkube-models
 ops
+pydantic
+pytest-interface-tester

--- a/src/charm.py
+++ b/src/charm.py
@@ -142,7 +142,7 @@ class SDCoreNMSOperatorCharm(CharmBase):
 
     @property
     def _environment_variables(self) -> dict:
-        """Returns environment variables for the nms container.
+        """Returns environment variables for the nms service.
 
         Returns:
             dict: Environment variables.

--- a/src/charm.py
+++ b/src/charm.py
@@ -9,6 +9,7 @@ import logging
 from charms.observability_libs.v1.kubernetes_service_patch import (  # type: ignore[import]
     KubernetesServicePatch,
 )
+from charms.sdcore_upf.v0.fiveg_n4 import N4Requires  # type: ignore[import]
 from charms.traefik_k8s.v1.ingress import IngressPerAppRequirer  # type: ignore[import]
 from lightkube.models.core_v1 import ServicePort
 from ops.charm import CharmBase
@@ -19,6 +20,7 @@ from ops.pebble import Layer
 
 logger = logging.getLogger(__name__)
 
+FIVEG_N4_RELATION_NAME = "fiveg_n4"
 NMS_PORT = 3000
 
 
@@ -30,6 +32,7 @@ class SDCoreNMSOperatorCharm(CharmBase):
         self._container_name = "nms"
         self._service_name = "sdcore-nms"
         self._container = self.unit.get_container(self._container_name)
+        self.fiveg_n4 = N4Requires(charm=self, relation_name=FIVEG_N4_RELATION_NAME)
         self._service_patcher = KubernetesServicePatch(
             charm=self,
             ports=[
@@ -45,6 +48,7 @@ class SDCoreNMSOperatorCharm(CharmBase):
 
         self.framework.observe(self.on.nms_pebble_ready, self._configure_sdcore_nms)
         self.framework.observe(self.on.config_changed, self._configure_sdcore_nms)
+        self.framework.observe(self.fiveg_n4.on.fiveg_n4_available, self._configure_sdcore_nms)
 
     def _configure_sdcore_nms(self, event: EventBase) -> None:
         """Add Pebble layer and manages Juju unit status.
@@ -56,22 +60,17 @@ class SDCoreNMSOperatorCharm(CharmBase):
             self.unit.status = WaitingStatus("Waiting for container to be ready")
             event.defer()
             return
-        if not self._config_is_valid():
-            self.unit.status = BlockedStatus("Config is not valid")
+        if not self.model.relations.get(FIVEG_N4_RELATION_NAME):
+            self.unit.status = BlockedStatus(
+                f"Waiting for `{FIVEG_N4_RELATION_NAME}` relation to be created"
+            )
+            return
+        if not self._webui_url_is_set():
+            self.unit.status = BlockedStatus("Invalid `webui-endpoint` config value")
             event.defer()
             return
         self._configure_pebble()
         self.unit.status = ActiveStatus()
-
-    def _config_is_valid(self) -> bool:
-        """Return whether the config is valid."""
-        if not self._webui_url_is_set():
-            return False
-        if not self._upf_hostname_is_set():
-            return False
-        if not self._upf_port_is_set():
-            return False
-        return True
 
     def _webui_url_is_set(self) -> bool:
         """Return whether the webui endpoint is set.
@@ -81,33 +80,43 @@ class SDCoreNMSOperatorCharm(CharmBase):
         """
         return self.config.get("webui-endpoint", "") != ""
 
-    def _upf_hostname_is_set(self) -> bool:
-        """Return whether the UPF hostname is set.
-
-        Return:
-            bool: Whether the UPF hostname is set.
-        """
-        return self.config.get("upf-hostname", "") != ""
-
-    def _upf_port_is_set(self) -> bool:
-        """Return whether the UPF port is set.
-
-        Return:
-            bool: Whether the UPF port is set.
-        """
-        return self.config.get("upf-port", "") != ""
-
-    def _configure_pebble(self, restart: bool = False) -> None:
-        """Configure the Pebble layer.
-
-        Args:
-            restart (bool): Whether to restart the Pebble service. Defaults to False.
-        """
+    def _configure_pebble(self) -> None:
+        """Configure the Pebble layer."""
         plan = self._container.get_plan()
         layer = self._pebble_layer
-        if plan.services != layer.services or restart:
+        if plan.services != layer.services:
             self._container.add_layer(self._container_name, layer, combine=True)
             self._container.restart(self._service_name)
+
+    def _get_upf_hostname(self) -> str:
+        """Gets UPF hostname from the `fiveg_n4` relation data bag.
+
+        Returns:
+            str: UPF hostname
+        """
+        fiveg_n4_relation = self.model.get_relation(FIVEG_N4_RELATION_NAME)
+        if not fiveg_n4_relation:
+            raise RuntimeError(f"Relation {FIVEG_N4_RELATION_NAME} not available")
+        if not fiveg_n4_relation.app:
+            raise RuntimeError(
+                f"Application missing from the {FIVEG_N4_RELATION_NAME} relation data"
+            )
+        return fiveg_n4_relation.data[fiveg_n4_relation.app]["upf_hostname"]
+
+    def _get_upf_port(self) -> int:
+        """Gets UPF's N4 port number from the `fiveg_n4` relation data bag.
+
+        Returns:
+            int: N4 port number
+        """
+        fiveg_n4_relation = self.model.get_relation(FIVEG_N4_RELATION_NAME)
+        if not fiveg_n4_relation:
+            raise RuntimeError(f"Relation {FIVEG_N4_RELATION_NAME} not available")
+        if not fiveg_n4_relation.app:
+            raise RuntimeError(
+                f"Application missing from the {FIVEG_N4_RELATION_NAME} relation data"
+            )
+        return int(fiveg_n4_relation.data[fiveg_n4_relation.app]["upf_port"])
 
     @property
     def _pebble_layer(self) -> Layer:
@@ -125,15 +134,24 @@ class SDCoreNMSOperatorCharm(CharmBase):
                         "override": "replace",
                         "startup": "enabled",
                         "command": "/bin/bash -c 'cd /app && npm run start'",
-                        "environment": {
-                            "WEBUI_ENDPOINT": self.config["webui-endpoint"],
-                            "UPF_HOSTNAME": self.config["upf-hostname"],
-                            "UPF_PORT": self.config["upf-port"],
-                        },
+                        "environment": self._environment_variables,
                     },
                 },
             }
         )
+
+    @property
+    def _environment_variables(self) -> dict:
+        """Returns environment variables for the nms container.
+
+        Returns:
+            dict: Environment variables.
+        """
+        return {
+            "WEBUI_ENDPOINT": self.config["webui-endpoint"],
+            "UPF_HOSTNAME": self._get_upf_hostname(),
+            "UPF_PORT": self._get_upf_port(),
+        }
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -122,6 +122,7 @@ async def test_given_fiveg_n4_relation_not_created_when_deploy_charm_then_status
         timeout=1000,
     )
 
+
 @pytest.mark.abort_on_fail
 async def test_given_sdcore_nms_waiting_for_fiveg_n4_relation_when_fiveg_n4_relation_created_then_status_is_active(  # noqa: E501
     ops_test,
@@ -138,9 +139,7 @@ async def test_given_sdcore_nms_waiting_for_fiveg_n4_relation_when_fiveg_n4_rela
 
 
 @pytest.mark.abort_on_fail
-async def test_given_traefik_deployed_when_relate_to_ingress_then_status_is_active(
-    ops_test,
-):
+async def test_given_traefik_deployed_when_relate_to_ingress_then_status_is_active(ops_test):
     await deploy_traefik(ops_test)
     await ops_test.model.add_relation(
         relation1=f"{APP_NAME}:ingress", relation2=f"{TRAEFIK_APP_NAME}:ingress"
@@ -153,9 +152,7 @@ async def test_given_traefik_deployed_when_relate_to_ingress_then_status_is_acti
 
 
 @pytest.mark.abort_on_fail
-async def test_given_related_to_traefik_when_fetch_ui_then_returns_html_content(
-    ops_test,
-):
+async def test_given_related_to_traefik_when_fetch_ui_then_returns_html_content(ops_test):
     nms_url = await get_sdcore_nms_endpoint(ops_test)
     traefik_ip = await get_traefik_ip(ops_test)
     nms_host = _get_host_from_url(nms_url)

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -17,6 +17,7 @@ logger = logging.getLogger(__name__)
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 APP_NAME = METADATA["name"]
 TRAEFIK_APP_NAME = "traefik"
+UPF_APP_NAME = "upf"
 
 
 @pytest.mark.abort_on_fail
@@ -30,11 +31,7 @@ async def build_and_deploy(ops_test):
         charm,
         resources=resources,
         application_name=APP_NAME,
-        config={
-            "webui-endpoint": "http://1.2.3.4:1234",
-            "upf-hostname": "upf",
-            "upf-port": "1234",
-        },
+        config={"webui-endpoint": "http://1.2.3.4:1234"},
         trust=True,
     )
 
@@ -46,6 +43,17 @@ async def deploy_traefik(ops_test):
         "traefik-k8s",
         application_name=TRAEFIK_APP_NAME,
         config={"external_hostname": "pizza.com", "routing_mode": "subdomain"},
+        trust=True,
+    )
+
+
+@pytest.mark.abort_on_fail
+async def deploy_sdcore_upf(ops_test):
+    """Deploy sdcore-upf-operator."""
+    await ops_test.model.deploy(
+        "sdcore-upf",
+        application_name=UPF_APP_NAME,
+        channel="edge",
         trust=True,
     )
 
@@ -104,12 +112,26 @@ def ui_is_running(ip: str, host: str) -> bool:
 
 
 @pytest.mark.abort_on_fail
-async def test_given_webui_config_when_deploy_charm_then_status_is_active(
+async def test_given_fiveg_n4_relation_not_created_when_deploy_charm_then_status_is_blocked(
     ops_test,
 ):
     await build_and_deploy(ops_test)
     await ops_test.model.wait_for_idle(
         apps=[APP_NAME],
+        status="blocked",
+        timeout=1000,
+    )
+
+@pytest.mark.abort_on_fail
+async def test_given_sdcore_nms_waiting_for_fiveg_n4_relation_when_fiveg_n4_relation_created_then_status_is_active(  # noqa: E501
+    ops_test,
+):
+    await deploy_sdcore_upf(ops_test)
+    await ops_test.model.add_relation(
+        relation1=f"{APP_NAME}:fiveg_n4", relation2=f"{UPF_APP_NAME}:fiveg_n4"
+    )
+    await ops_test.model.wait_for_idle(
+        apps=[APP_NAME, UPF_APP_NAME],
         status="active",
         timeout=1000,
     )

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -26,9 +26,7 @@ class TestCharm(unittest.TestCase):
     def test_given_cant_connect_to_container_when_config_changed_then_status_is_waiting(self):
         self.harness.set_can_connect(container="nms", val=False)
 
-        self.harness.update_config(
-            key_values={"webui-endpoint": "banana"}
-        )
+        self.harness.update_config(key_values={"webui-endpoint": "banana"})
 
         self.assertEqual(
             self.harness.model.unit.status, WaitingStatus("Waiting for container to be ready")
@@ -39,19 +37,17 @@ class TestCharm(unittest.TestCase):
 
         self.assertEqual(
             self.harness.model.unit.status,
-            BlockedStatus(f"Waiting for `{FIVEG_N4_RELATION_NAME}` relation to be created")
+            BlockedStatus(f"Waiting for `{FIVEG_N4_RELATION_NAME}` relation to be created"),
         )
 
     def test_given_fiveg_n4_relation_not_created_when_config_changed_then_status_is_blocked(self):
         self.harness.set_can_connect(container="nms", val=True)
 
-        self.harness.update_config(
-            key_values={"webui-endpoint": "banana"}
-        )
+        self.harness.update_config(key_values={"webui-endpoint": "banana"})
 
         self.assertEqual(
             self.harness.model.unit.status,
-            BlockedStatus(f"Waiting for `{FIVEG_N4_RELATION_NAME}` relation to be created")
+            BlockedStatus(f"Waiting for `{FIVEG_N4_RELATION_NAME}` relation to be created"),
         )
 
     @patch("ops.model.Container.exists")
@@ -83,12 +79,10 @@ class TestCharm(unittest.TestCase):
         self.harness.update_relation_data(
             relation_id=fiveg_n4_relation_id,
             app_or_unit=TEST_FIVEG_N4_PROVIDER_APP_NAME,
-            key_values={"upf_hostname": test_upf_hostname, "upf_port": test_upf_port}
+            key_values={"upf_hostname": test_upf_hostname, "upf_port": test_upf_port},
         )
 
-        self.harness.update_config(
-            key_values={"webui-endpoint": "banana"}
-        )
+        self.harness.update_config(key_values={"webui-endpoint": "banana"})
 
         expected_plan = {
             "services": {
@@ -119,7 +113,7 @@ class TestCharm(unittest.TestCase):
         self.harness.update_relation_data(
             relation_id=fiveg_n4_relation_id,
             app_or_unit=TEST_FIVEG_N4_PROVIDER_APP_NAME,
-            key_values={"upf_hostname": "some.host.name", "upf_port": "1234"}
+            key_values={"upf_hostname": "some.host.name", "upf_port": "1234"},
         )
 
         self.harness.update_config({"webui-endpoint": "banana"})

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -9,19 +9,8 @@ from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
 
 from charm import SDCoreNMSOperatorCharm
 
-
-def read_file(path: str) -> str:
-    """Reads a file and returns as a string.
-
-    Args:
-        path (str): path to the file.
-
-    Returns:
-        str: content of the file.
-    """
-    with open(path, "r") as f:
-        content = f.read()
-    return content
+FIVEG_N4_RELATION_NAME = "fiveg_n4"
+TEST_FIVEG_N4_PROVIDER_APP_NAME = "fiveg_n4_provider_app"
 
 
 class TestCharm(unittest.TestCase):
@@ -34,35 +23,71 @@ class TestCharm(unittest.TestCase):
         self.addCleanup(self.harness.cleanup)
         self.harness.begin()
 
-    def test_given_cant_connect_to_container_when_config_changed_then_status_is_waiting(
-        self,
-    ):
+    def test_given_cant_connect_to_container_when_config_changed_then_status_is_waiting(self):
         self.harness.set_can_connect(container="nms", val=False)
 
         self.harness.update_config(
-            key_values={"webui-endpoint": "banana", "upf-hostname": "pizza", "upf-port": 1234}
+            key_values={"webui-endpoint": "banana"}
         )
 
         self.assertEqual(
             self.harness.model.unit.status, WaitingStatus("Waiting for container to be ready")
         )
 
+    def test_given_fiveg_n4_relation_not_created_when_pebble_ready_then_status_is_blocked(self):
+        self.harness.container_pebble_ready(container_name="nms")
+
+        self.assertEqual(
+            self.harness.model.unit.status,
+            BlockedStatus(f"Waiting for `{FIVEG_N4_RELATION_NAME}` relation to be created")
+        )
+
+    def test_given_fiveg_n4_relation_not_created_when_config_changed_then_status_is_blocked(self):
+        self.harness.set_can_connect(container="nms", val=True)
+
+        self.harness.update_config(
+            key_values={"webui-endpoint": "banana"}
+        )
+
+        self.assertEqual(
+            self.harness.model.unit.status,
+            BlockedStatus(f"Waiting for `{FIVEG_N4_RELATION_NAME}` relation to be created")
+        )
+
     @patch("ops.model.Container.exists")
     def test_given_config_not_valid_when_config_changed_then_status_is_waiting(self, patch_exists):
         patch_exists.return_value = True
         self.harness.set_can_connect(container="nms", val=True)
+        self.harness.add_relation(
+            relation_name=FIVEG_N4_RELATION_NAME,
+            remote_app=TEST_FIVEG_N4_PROVIDER_APP_NAME,
+        )
 
         self.harness.update_config(key_values={"webui-endpoint": ""})
 
-        self.assertEqual(self.harness.model.unit.status, BlockedStatus("Config is not valid"))
+        self.assertEqual(
+            self.harness.model.unit.status,
+            BlockedStatus("Invalid `webui-endpoint` config value"),
+        )
 
-    def test_given_can_connect_when_config_changed_then_pebble_plan_is_applied(
+    def test_given_config_is_valid_and_fiveg_n4_relation_is_created_when_config_changed_then_pebble_plan_is_applied(  # noqa: E501
         self,
     ):
+        test_upf_hostname = "some.host.name"
+        test_upf_port = "1234"
         self.harness.set_can_connect(container="nms", val=True)
+        fiveg_n4_relation_id = self.harness.add_relation(
+            relation_name=FIVEG_N4_RELATION_NAME,
+            remote_app=TEST_FIVEG_N4_PROVIDER_APP_NAME,
+        )
+        self.harness.update_relation_data(
+            relation_id=fiveg_n4_relation_id,
+            app_or_unit=TEST_FIVEG_N4_PROVIDER_APP_NAME,
+            key_values={"upf_hostname": test_upf_hostname, "upf_port": test_upf_port}
+        )
 
         self.harness.update_config(
-            key_values={"webui-endpoint": "banana", "upf-hostname": "upf", "upf-port": 1234}
+            key_values={"webui-endpoint": "banana"}
         )
 
         expected_plan = {
@@ -72,8 +97,8 @@ class TestCharm(unittest.TestCase):
                     "override": "replace",
                     "command": "/bin/bash -c 'cd /app && npm run start'",
                     "environment": {
-                        "UPF_HOSTNAME": "upf",
-                        "UPF_PORT": 1234,
+                        "UPF_HOSTNAME": test_upf_hostname,
+                        "UPF_PORT": int(test_upf_port),
                         "WEBUI_ENDPOINT": "banana",
                     },
                 }
@@ -83,10 +108,19 @@ class TestCharm(unittest.TestCase):
 
         self.assertEqual(expected_plan, updated_plan)
 
-    def test_given_can_connect_when_config_changed_then_status_is_active(
+    def test_given_config_is_valid_and_fiveg_n4_relation_is_created_when_config_changed_then_status_is_active(  # noqa: E501
         self,
     ):
         self.harness.set_can_connect(container="nms", val=True)
+        fiveg_n4_relation_id = self.harness.add_relation(
+            relation_name=FIVEG_N4_RELATION_NAME,
+            remote_app=TEST_FIVEG_N4_PROVIDER_APP_NAME,
+        )
+        self.harness.update_relation_data(
+            relation_id=fiveg_n4_relation_id,
+            app_or_unit=TEST_FIVEG_N4_PROVIDER_APP_NAME,
+            key_values={"upf_hostname": "some.host.name", "upf_port": "1234"}
+        )
 
         self.harness.update_config({"webui-endpoint": "banana"})
 


### PR DESCRIPTION
# Description

Implements the requirer side of the `fiveg_n4` relation.
From now on, UPF hostname and port will be taken from the relation data instead of config params.
For now, the limit of connected `fiveg_n4` relations is set to one.

**Reference:**
https://docs.google.com/document/d/1s3U82GTUZFJ9mEhiHig0oAl44F0fq3eQT2PNv1uV75g

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of the library