### PR TITLE
Implement requirer side of the fiveg_gnb_identity relation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,17 +8,19 @@ Charmed Operator for SD-Core's NMS.
 juju deploy sdcore-nms --channel=edge
 ```
 
-## Integrate with ingress
+## Integrate
 
 ```bash
 juju deploy traefik-k8s --trust --config external_hostname=<your hostname> --config routing_mode=subdomain
 juju deploy sdcore-upf --channel=edge --trust
 juju deploy mongodb-k8s --trust --channel=5/edge
 juju deploy sdcore-webui --trust --channel=edge
+juju deploy sdcore-gnbsim --trust --channel=edge
 juju integrate mongodb-k8s sdcore-webui
 juju integrate sdcore-nms:ingress traefik-k8s:ingress
 juju integrate sdcore-nms:fiveg_n4 sdcore-upf:fiveg_n4
 juju integrate sdcore-nms:sdcore-management sdcore-webui:sdcore-management
+juju integrate sdcore-nms:fiveg_gnb_identity sdcore-gnbsim:fiveg_gnb_identity
 ```
 
 You should now be able to access the NMS at `https://<model name>-sdcore-nms.<your hostname>`

--- a/lib/charms/sdcore_gnbsim/v0/fiveg_gnb_identity.py
+++ b/lib/charms/sdcore_gnbsim/v0/fiveg_gnb_identity.py
@@ -1,0 +1,306 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Library for the `fiveg_gnb_identity` relation.
+
+This library contains the Requires and Provides classes for handling the `fiveg_gnb_identity`
+interface.
+
+The purpose of this library is to provide a way for gNodeB's to share their identity with the charms which require this information.
+
+To get started using the library, you need to fetch the library using `charmcraft`.
+
+```shell
+cd some-charm
+charmcraft fetch-lib charms.sdcore_gnbsim.v0.fiveg_gnb_identity
+```
+
+Add the following libraries to the charm's `requirements.txt` file:
+- pydantic
+- pytest-interface-tester
+
+Charms providing the `fiveg_gnb_identity` relation should use `GnbIdentityProvides`.
+Typical usage of this class would look something like:
+
+    ```python
+    ...
+    from charms.sdcore_gnbsim.v0.fiveg_gnb_identity import GnbIdentityProvides
+    ...
+
+    class SomeProviderCharm(CharmBase):
+
+        def __init__(self, *args):
+            ...
+            self.gnb_identity_provider = GnbIdentityProvides(charm=self, relation_name="fiveg_gnb_identity")
+            ...
+            self.framework.observe(self.gnb_identity_provider.on.fiveg_gnb_identity_request, self._on_fiveg_gnb_identity_request)
+
+        def _on_fiveg_gnb_identity_request(self, event):
+            ...
+            self.gnb_identity_provider.publish_gnb_identity_information(
+                relation_id=event.relation_id,
+                gnb_name=name,
+                tac=tac,
+            )
+    ```
+
+    And a corresponding section in charm's `metadata.yaml`:
+    ```
+    provides:
+        fiveg_gnb_identity:  # Relation name
+            interface: fiveg_gnb_identity  # Relation interface
+    ```
+
+Charms that require the `fiveg_gnb_identity` relation should use `GnbIdentityRequires`.
+Typical usage of this class would look something like:
+
+    ```python
+    ...
+    from charms.sdcore_gnbsim.v0.fiveg_gnb_identity import GnbIdentityRequires
+    ...
+
+    class SomeRequirerCharm(CharmBase):
+
+        def __init__(self, *args):
+            ...
+            self.fiveg_gnb_identity = GnbIdentityRequires(charm=self, relation_name="fiveg_gnb_identity")
+            ...
+            self.framework.observe(self.fiveg_gnb_identity.on.fiveg_gnb_identity_available, 
+                self._on_fiveg_gnb_identity_available)
+
+        def _on_fiveg_gnb_identity_available(self, event):
+            gnb_name = event.gnb_name,
+            tac = event.tac,
+            # Do something with the gNB's name and TAC.
+    ```
+
+    And a corresponding section in charm's `metadata.yaml`:
+    ```
+    requires:
+        fiveg_gnb_identity:  # Relation name
+            interface: fiveg_gnb_identity  # Relation interface
+    ```
+"""
+
+import logging
+
+from interface_tester.schema_base import DataBagSchema  # type: ignore[import]
+from ops.charm import CharmBase, CharmEvents, RelationChangedEvent, RelationJoinedEvent
+from ops.framework import EventBase, EventSource, Handle, Object
+from pydantic import BaseModel, Field, ValidationError
+
+# The unique Charmhub library identifier, never change it
+LIBID = "ca9a66c5806e47e7b2750e8cdf696b80"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 1
+
+PYDEPS = ["pydantic", "pytest-interface-tester"]
+
+
+logger = logging.getLogger(__name__)
+
+"""Schemas definition for the provider and requirer sides of the `fiveg_gnb_identity` interface.
+It exposes two interfaces.schema_base.DataBagSchema subclasses called:
+- ProviderSchema
+- RequirerSchema
+
+Examples:
+    ProviderSchema:
+        unit: <empty>
+        app: {
+            "gnb_name": "gnb001",
+            "tac": 1
+        }
+    RequirerSchema:
+        unit: <empty>
+        app:  <empty>
+"""
+
+
+class FivegGnbIdentityProviderAppData(BaseModel):
+    """Provider app data for fiveg_gnb_identity."""
+
+    gnb_name: str = Field(
+        description="Name of the gnB.",
+        examples=["gnb001"]
+    )
+    tac: int = Field(
+        description="Tracking Area Code",
+        examples=[1]
+    )
+
+class ProviderSchema(DataBagSchema):
+    """Provider schema for fiveg_gnb_identity."""
+
+    app: FivegGnbIdentityProviderAppData
+
+
+def data_matches_provider_schema(data: dict) -> bool:
+    """Returns whether data matches provider schema.
+
+    Args:
+        data (dict): Data to be validated.
+
+    Returns:
+        bool: True if data matches provider schema, False otherwise.
+    """
+    try:
+        ProviderSchema(app=data)
+        return True
+    except ValidationError as e:
+        logger.error("Invalid data: %s", e)
+        return False
+
+
+class FivegGnbIdentityRequestEvent(EventBase):
+    """Dataclass for the `fiveg_gnb_identity` request event."""
+
+    def __init__(self, handle: Handle, relation_id: int):
+        """Sets relation id.
+        
+        Args:
+            handle (Handle): Juju framework handle.
+            relation_id : ID of the relation.
+        """
+        super().__init__(handle)
+        self.relation_id = relation_id
+
+    def snapshot(self) -> dict:
+        """Returns event data.
+        
+        Returns:
+            (dict): contains the relation ID.
+        """
+        return {
+            "relation_id": self.relation_id,
+        }
+
+    def restore(self, snapshot: dict) -> None:
+        """Restores event data.
+        
+        Args:
+            snapshot (dict): contains the relation ID.
+        """
+        self.relation_id = snapshot["relation_id"]
+
+
+class GnbIdentityProviderCharmEvents(CharmEvents):
+    """Custom events for the GnbIdentityProvider."""
+
+    fiveg_gnb_identity_request = EventSource(FivegGnbIdentityRequestEvent)
+
+
+class GnbIdentityProvides(Object):
+    """Class to be instantiated by provider of the `fiveg_gnb_identity`."""
+
+    on = GnbIdentityProviderCharmEvents()
+
+    def __init__(self, charm: CharmBase, relation_name: str):
+        """Observes relation joined event.
+
+        Args:
+            charm: Juju charm
+            relation_name (str): Relation name
+        """
+        self.relation_name = relation_name
+        self.charm = charm
+        super().__init__(charm, relation_name)
+        self.framework.observe(charm.on[relation_name].relation_joined, self._on_relation_joined)
+
+    def publish_gnb_identity_information(
+        self, relation_id: int, gnb_name: str, tac: int
+    ) -> None:
+        """Sets gNodeB's name and TAC in the relation data.
+
+        Args:
+            relation_id (str): Relation ID
+            gnb_name (str): name of the gNodeB.
+            tac (int): Tracking Area Code.
+        """
+        if not data_matches_provider_schema(
+            data={"gnb_name": gnb_name, "tac": tac}
+        ):
+            raise ValueError(f"Invalid gnb identity data: {gnb_name}, {tac}")
+        relation = self.model.get_relation(
+            relation_name=self.relation_name, relation_id=relation_id
+        )
+        if not relation:
+            raise RuntimeError(f"Relation {self.relation_name} not created yet.")
+        relation.data[self.charm.app]["gnb_name"] = gnb_name
+        relation.data[self.charm.app]["tac"] = str(tac)
+
+    def _on_relation_joined(self, event: RelationJoinedEvent) -> None:
+        """Triggered whenever a requirer charm joins the relation.
+
+        Args:
+            event (RelationJoinedEvent): Juju event
+        """
+        self.on.fiveg_gnb_identity_request.emit(relation_id=event.relation.id)
+
+
+class GnbIdentityAvailableEvent(EventBase):
+    """Dataclass for the `fiveg_gnb_identity` available event."""
+
+    def __init__(self, handle: Handle, gnb_name: str, tac: str):
+        """Sets gNodeB's name and TAC."""
+        super().__init__(handle)
+        self.gnb_name = gnb_name
+        self.tac = tac
+
+    def snapshot(self) -> dict:
+        """Returns event data."""
+        return {
+            "gnb_name": self.gnb_name,
+            "tac": self.tac,
+        }
+
+    def restore(self, snapshot: dict) -> None:
+        """Restores event data.
+        
+        Args:
+            snapshot (dict): contains information to be restored.
+        """
+        self.gnb_name = snapshot["gnb_name"]
+        self.tac = snapshot["tac"]
+
+
+class GnbIdentityRequirerCharmEvents(CharmEvents):
+    """Custom events for the GnbIdentityRequirer."""
+
+    fiveg_gnb_identity_available = EventSource(GnbIdentityAvailableEvent)
+
+
+class GnbIdentityRequires(Object):
+    """Class to be instantiated by requirer of the `fiveg_gnb_identity`."""
+
+    on = GnbIdentityRequirerCharmEvents()
+
+    def __init__(self, charm: CharmBase, relation_name: str):
+        """Observes relation joined and relation changed events.
+
+        Args:
+            charm: Juju charm
+            relation_name (str): Relation name
+        """
+        self.relation_name = relation_name
+        self.charm = charm
+        super().__init__(charm, relation_name)
+        self.framework.observe(charm.on[relation_name].relation_joined, self._on_relation_changed)
+        self.framework.observe(charm.on[relation_name].relation_changed, self._on_relation_changed)
+
+    def _on_relation_changed(self, event: RelationChangedEvent) -> None:
+        """Triggered everytime there's a change in relation data.
+
+        Args:
+            event (RelationChangedEvent): Juju event
+        """
+        relation_data = event.relation.data
+        gnb_name = relation_data[event.app].get("gnb_name")  # type: ignore[index]
+        tac = relation_data[event.app].get("tac")  # type: ignore[index]
+        if gnb_name and tac:
+            self.on.fiveg_gnb_identity_available.emit(gnb_name=gnb_name, tac=tac)

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -29,3 +29,5 @@ requires:
     limit: 1
   sdcore-management:
     interface: sdcore_management
+  fiveg_gnb_identity:
+    interface: fiveg_gnb_identity

--- a/src/charm.py
+++ b/src/charm.py
@@ -20,7 +20,7 @@ from lightkube.models.core_v1 import ServicePort
 from ops.charm import CharmBase
 from ops.framework import EventBase
 from ops.main import main
-from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
+from ops.model import ActiveStatus, BlockedStatus, Relation, WaitingStatus
 from ops.pebble import Layer
 
 logger = logging.getLogger(__name__)
@@ -147,14 +147,14 @@ class SDCoreNMSOperatorCharm(CharmBase):
         """
         if gnb_identity_relations := self.model.relations.get(GNB_IDENTITY_RELATION_NAME):
             for relation in gnb_identity_relations:
-                if not self._get_gnb_name(relation) or not self._get_tac(relation):
+                if not self._get_gnb_name(relation) or not self._get_gnb_tac(relation):
                     logger.warning(
                         "Invalid information in %s integration with %s",
                         GNB_IDENTITY_RELATION_NAME,
                         relation.app,
                     )
 
-    def _get_gnb_name(self, gnb_identity_relation) -> str:
+    def _get_gnb_name(self, gnb_identity_relation: Relation) -> str:
         """Gets gNB name from the `fiveg_gnb_identity` relation data bag.
 
         Returns:
@@ -166,7 +166,7 @@ class SDCoreNMSOperatorCharm(CharmBase):
             )
         return gnb_identity_relation.data[gnb_identity_relation.app].get("gnb_name", "")
 
-    def _get_tac(self, gnb_identity_relation) -> Optional[int]:
+    def _get_gnb_tac(self, gnb_identity_relation: Relation) -> Optional[int]:
         """Gets TAC from the `fiveg_gnb_identity` relation data bag.
 
         Returns:

--- a/src/charm.py
+++ b/src/charm.py
@@ -91,7 +91,7 @@ class SDCoreNMSOperatorCharm(CharmBase):
             event.defer()
             return
         if not self._fiveg_gnb_identity_is_provided():
-            self.unit.status = WaitingStatus("Waiting for gNB identity to be available")
+            self.unit.status = WaitingStatus("Waiting for gNB information to be available")
             event.defer()
             return
         self._configure_pebble()

--- a/src/charm.py
+++ b/src/charm.py
@@ -215,17 +215,6 @@ class SDCoreNMSOperatorCharm(CharmBase):
             "UPF_PORT": self._get_upf_port(),
         }
 
-    def _relation_created(self, relation_name: str) -> bool:
-        """Returns True if the relation is created, False otherwise.
-
-        Args:
-            relation_name (str): Name of the relation.
-
-        Returns:
-            bool: True if the relation is created, False otherwise.
-        """
-        return bool(self.model.relations.get(relation_name))
-
 
 if __name__ == "__main__":  # pragma: no cover
     main(SDCoreNMSOperatorCharm)

--- a/src/charm.py
+++ b/src/charm.py
@@ -86,11 +86,11 @@ class SDCoreNMSOperatorCharm(CharmBase):
             self.unit.status = WaitingStatus("Waiting for webui management url to be available")
             event.defer()
             return
-        if not self._fiveg_n4_is_provided():
+        if not self._fiveg_n4_information_is_correct():
             self.unit.status = WaitingStatus("Waiting for UPF information to be available")
             event.defer()
             return
-        if not self._fiveg_gnb_identity_is_provided():
+        if not self.fiveg_gnb_identity_information_is_correct():
             self.unit.status = WaitingStatus("Waiting for gNB information to be available")
             event.defer()
             return
@@ -105,13 +105,13 @@ class SDCoreNMSOperatorCharm(CharmBase):
             self._container.add_layer(self._container_name, layer, combine=True)
             self._container.restart(self._service_name)
 
-    def _fiveg_n4_is_provided(self) -> bool:
+    def _fiveg_n4_information_is_correct(self) -> bool:
         """The `fiveg_n4` relation is not mandatory and limited to 1.
 
         If it exists it must contain the UPF hostname and port.
 
         Returns:
-            Whether the `fiveg_n4` relation information is provided.
+            Whether the `fiveg_n4` relation information is correct.
         """
         if self.model.relations.get(FIVEG_N4_RELATION_NAME):
             if not self._get_upf_hostname() or not self._get_upf_port():
@@ -150,17 +150,18 @@ class SDCoreNMSOperatorCharm(CharmBase):
             return int(port)
         return None
 
-    def _fiveg_gnb_identity_is_provided(self) -> bool:
+    def fiveg_gnb_identity_information_is_correct(self) -> bool:
         """The `fiveg_gnb_identity` relation is not mandatory.
 
         If it exists it must contain the gNB name and TAC.
 
         Returns:
-            Whether the `fiveg_gnb_identity` relation information is provided.
+            Whether the `fiveg_gnb_identity` relation information is correct.
         """
-        for relation in self.model.relations.get(GNB_IDENTITY_RELATION_NAME):
-            if not self._get_gnb_name(relation) or not self._get_tac(relation):
-                return False
+        if gnb_identity_relations := self.model.relations.get(GNB_IDENTITY_RELATION_NAME):
+            for relation in gnb_identity_relations:
+                if not self._get_gnb_name(relation) or not self._get_tac(relation):
+                    return False
         return True
 
     def _get_gnb_name(self, gnb_identity_relation) -> str:

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -147,22 +147,7 @@ async def test_given_required_relations_not_created_when_deploy_charm_then_statu
 
 
 @pytest.mark.abort_on_fail
-async def test_given_only_fiveg_n4_relation_when_deploy_charm_then_status_is_blocked(
-    ops_test,
-):
-    await deploy_sdcore_upf(ops_test)
-    await ops_test.model.integrate(
-        relation1=f"{APP_NAME}:fiveg_n4", relation2=f"{UPF_APP_NAME}:fiveg_n4"
-    )
-    await ops_test.model.wait_for_idle(
-        apps=[APP_NAME],
-        status="blocked",
-        timeout=1000,
-    )
-
-
-@pytest.mark.abort_on_fail
-async def test_given_no_fiveg_identity_relation_when_deploy_charm_then_status_is_blocked(
+async def test_given_sdcore_management_relation_creted_when_deploy_charm_then_status_is_active(
     ops_test,
 ):
     await deploy_sdcore_webui(ops_test)
@@ -171,13 +156,26 @@ async def test_given_no_fiveg_identity_relation_when_deploy_charm_then_status_is
     )
     await ops_test.model.wait_for_idle(
         apps=[APP_NAME],
-        status="blocked",
+        status="active",
         timeout=1000,
     )
 
+@pytest.mark.abort_on_fail
+async def test_given_fiveg_n4_relation_when_deploy_charm_then_status_is_active(
+    ops_test,
+):
+    await deploy_sdcore_upf(ops_test)
+    await ops_test.model.integrate(
+        relation1=f"{APP_NAME}:fiveg_n4", relation2=f"{UPF_APP_NAME}:fiveg_n4"
+    )
+    await ops_test.model.wait_for_idle(
+        apps=[APP_NAME],
+        status="active",
+        timeout=1000,
+    )
 
 @pytest.mark.abort_on_fail
-async def test_given_all_required_relations_created_when_deploy_charm_then_status_is_active(
+async def test_given_fiveg_gnb_identity_created_when_deploy_charm_then_status_is_active(
     ops_test,
 ):
     await deploy_sdcore_gnbsim(ops_test)

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -19,6 +19,7 @@ APP_NAME = METADATA["name"]
 TRAEFIK_APP_NAME = "traefik"
 UPF_APP_NAME = "upf"
 WEBUI_APP_NAME = "webui"
+GNBSIM_APP_NAME = "gnbsim"
 
 
 @pytest.mark.abort_on_fail
@@ -64,6 +65,17 @@ async def deploy_sdcore_webui(ops_test):
     await ops_test.model.deploy(
         "sdcore-webui",
         application_name=WEBUI_APP_NAME,
+        channel="edge",
+        trust=True,
+    )
+
+
+@pytest.mark.abort_on_fail
+async def deploy_sdcore_gnbsim(ops_test):
+    """Deploy sdcore-gnbsim-operator."""
+    await ops_test.model.deploy(
+        "sdcore-gnbsim",
+        application_name=GNBSIM_APP_NAME,
         channel="edge",
         trust=True,
     )
@@ -135,7 +147,7 @@ async def test_given_required_relations_not_created_when_deploy_charm_then_statu
 
 
 @pytest.mark.abort_on_fail
-async def test_given_sdcore_management_relation_not_created_when_deploy_charm_then_status_is_blocked(  # noqa: E501
+async def test_given_only_fiveg_n4_relation_when_deploy_charm_then_status_is_blocked(
     ops_test,
 ):
     await deploy_sdcore_upf(ops_test)
@@ -150,12 +162,28 @@ async def test_given_sdcore_management_relation_not_created_when_deploy_charm_th
 
 
 @pytest.mark.abort_on_fail
-async def test_given_sdcore_nms_deployed_when_required_relations_created_then_status_is_active(
+async def test_given_no_fiveg_identity_relation_when_deploy_charm_then_status_is_blocked(
     ops_test,
 ):
     await deploy_sdcore_webui(ops_test)
     await ops_test.model.add_relation(
         relation1=f"{APP_NAME}:sdcore-management", relation2=f"{WEBUI_APP_NAME}:sdcore-management"
+    )
+    await ops_test.model.wait_for_idle(
+        apps=[APP_NAME],
+        status="blocked",
+        timeout=1000,
+    )
+
+
+@pytest.mark.abort_on_fail
+async def test_given_all_required_relations_created_when_deploy_charm_then_status_is_active(
+    ops_test,
+):
+    await deploy_sdcore_gnbsim(ops_test)
+    await ops_test.model.add_relation(
+        relation1=f"{APP_NAME}:fiveg_gnb_identity",
+        relation2=f"{deploy_sdcore_gnbsim}:fiveg_gnb_identity",
     )
     await ops_test.model.wait_for_idle(
         apps=[APP_NAME, UPF_APP_NAME],

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -147,7 +147,7 @@ async def test_given_required_relations_not_created_when_deploy_charm_then_statu
 
 
 @pytest.mark.abort_on_fail
-async def test_given_sdcore_management_relation_creted_when_deploy_charm_then_status_is_active(
+async def test_given_sdcore_management_relation_created_when_deploy_charm_then_status_is_active(
     ops_test,
 ):
     await deploy_sdcore_webui(ops_test)
@@ -159,6 +159,7 @@ async def test_given_sdcore_management_relation_creted_when_deploy_charm_then_st
         status="active",
         timeout=1000,
     )
+
 
 @pytest.mark.abort_on_fail
 async def test_given_fiveg_n4_relation_when_deploy_charm_then_status_is_active(
@@ -173,6 +174,7 @@ async def test_given_fiveg_n4_relation_when_deploy_charm_then_status_is_active(
         status="active",
         timeout=1000,
     )
+
 
 @pytest.mark.abort_on_fail
 async def test_given_fiveg_gnb_identity_created_when_deploy_charm_then_status_is_active(

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -151,7 +151,7 @@ async def test_given_only_fiveg_n4_relation_when_deploy_charm_then_status_is_blo
     ops_test,
 ):
     await deploy_sdcore_upf(ops_test)
-    await ops_test.model.add_relation(
+    await ops_test.model.integrate(
         relation1=f"{APP_NAME}:fiveg_n4", relation2=f"{UPF_APP_NAME}:fiveg_n4"
     )
     await ops_test.model.wait_for_idle(
@@ -166,7 +166,7 @@ async def test_given_no_fiveg_identity_relation_when_deploy_charm_then_status_is
     ops_test,
 ):
     await deploy_sdcore_webui(ops_test)
-    await ops_test.model.add_relation(
+    await ops_test.model.integrate(
         relation1=f"{APP_NAME}:sdcore-management", relation2=f"{WEBUI_APP_NAME}:sdcore-management"
     )
     await ops_test.model.wait_for_idle(
@@ -181,9 +181,9 @@ async def test_given_all_required_relations_created_when_deploy_charm_then_statu
     ops_test,
 ):
     await deploy_sdcore_gnbsim(ops_test)
-    await ops_test.model.add_relation(
+    await ops_test.model.integrate(
         relation1=f"{APP_NAME}:fiveg_gnb_identity",
-        relation2=f"{deploy_sdcore_gnbsim}:fiveg_gnb_identity",
+        relation2=f"{GNBSIM_APP_NAME}:fiveg_gnb_identity",
     )
     await ops_test.model.wait_for_idle(
         apps=[APP_NAME, UPF_APP_NAME],
@@ -195,7 +195,7 @@ async def test_given_all_required_relations_created_when_deploy_charm_then_statu
 @pytest.mark.abort_on_fail
 async def test_given_traefik_deployed_when_relate_to_ingress_then_status_is_active(ops_test):
     await deploy_traefik(ops_test)
-    await ops_test.model.add_relation(
+    await ops_test.model.integrate(
         relation1=f"{APP_NAME}:ingress", relation2=f"{TRAEFIK_APP_NAME}:ingress"
     )
     await ops_test.model.wait_for_idle(

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -13,6 +13,8 @@ FIVEG_N4_RELATION_NAME = "fiveg_n4"
 TEST_FIVEG_N4_PROVIDER_APP_NAME = "fiveg_n4_provider_app"
 SDCORE_MANAGEMENT_RELATION_NAME = "sdcore-management"
 TEST_SDCORE_MANAGEMENT_PROVIDER_APP_NAME = "sdcore_management_provider_app"
+GNB_IDENTITY_RELATION_NAME = "fiveg_gnb_identity"
+TEST_GNB_IDENTITY_PROVIDER_APP_NAME = "fiveg_gnb_identity_provider_app"
 
 
 class TestCharm(unittest.TestCase):
@@ -38,6 +40,10 @@ class TestCharm(unittest.TestCase):
             relation_name=SDCORE_MANAGEMENT_RELATION_NAME,
             remote_app=TEST_SDCORE_MANAGEMENT_PROVIDER_APP_NAME,
         )
+        self.harness.add_relation(
+            relation_name=GNB_IDENTITY_RELATION_NAME,
+            remote_app=TEST_GNB_IDENTITY_PROVIDER_APP_NAME,
+        )
         self.harness.container_pebble_ready("nms")
         self.assertEqual(
             self.harness.model.unit.status,
@@ -51,11 +57,34 @@ class TestCharm(unittest.TestCase):
             relation_name=FIVEG_N4_RELATION_NAME,
             remote_app=TEST_FIVEG_N4_PROVIDER_APP_NAME,
         )
+        self.harness.add_relation(
+            relation_name=GNB_IDENTITY_RELATION_NAME,
+            remote_app=TEST_GNB_IDENTITY_PROVIDER_APP_NAME,
+        )
         self.harness.container_pebble_ready("nms")
         self.assertEqual(
             self.harness.model.unit.status,
             BlockedStatus(
                 f"Waiting for `{SDCORE_MANAGEMENT_RELATION_NAME}` relation to be created",
+            ),
+        )
+
+    def test_given_fiveg_gnb_identity_relation_not_created_when_pebble_ready_then_status_is_blocked(  # noqa: E501
+        self,
+    ):
+        self.harness.add_relation(
+            relation_name=FIVEG_N4_RELATION_NAME,
+            remote_app=TEST_FIVEG_N4_PROVIDER_APP_NAME,
+        )
+        self.harness.add_relation(
+            relation_name=SDCORE_MANAGEMENT_RELATION_NAME,
+            remote_app=TEST_SDCORE_MANAGEMENT_PROVIDER_APP_NAME,
+        )
+        self.harness.container_pebble_ready("nms")
+        self.assertEqual(
+            self.harness.model.unit.status,
+            BlockedStatus(
+                f"Waiting for `{GNB_IDENTITY_RELATION_NAME}` relation to be created",
             ),
         )
 
@@ -69,10 +98,21 @@ class TestCharm(unittest.TestCase):
             app_or_unit=TEST_FIVEG_N4_PROVIDER_APP_NAME,
             key_values={"upf_hostname": "some.host.name", "upf_port": "1234"},
         )
+        gnb_identity_relation_id = self.harness.add_relation(
+            relation_name=GNB_IDENTITY_RELATION_NAME,
+            remote_app=TEST_GNB_IDENTITY_PROVIDER_APP_NAME,
+        )
+        self.harness.update_relation_data(
+            relation_id=gnb_identity_relation_id,
+            app_or_unit=TEST_GNB_IDENTITY_PROVIDER_APP_NAME,
+            key_values={"gnb_name": "some.gnb", "tac": "1234"},
+        )
+
         self.harness.add_relation(
             relation_name=SDCORE_MANAGEMENT_RELATION_NAME,
             remote_app=TEST_SDCORE_MANAGEMENT_PROVIDER_APP_NAME,
         )
+
         self.harness.container_pebble_ready("nms")
         self.assertEqual(
             self.harness.model.unit.status,
@@ -84,6 +124,16 @@ class TestCharm(unittest.TestCase):
             relation_name=FIVEG_N4_RELATION_NAME,
             remote_app=TEST_FIVEG_N4_PROVIDER_APP_NAME,
         )
+        gnb_identity_relation_id = self.harness.add_relation(
+            relation_name=GNB_IDENTITY_RELATION_NAME,
+            remote_app=TEST_GNB_IDENTITY_PROVIDER_APP_NAME,
+        )
+        self.harness.update_relation_data(
+            relation_id=gnb_identity_relation_id,
+            app_or_unit=TEST_GNB_IDENTITY_PROVIDER_APP_NAME,
+            key_values={"gnb_name": "some.gnb", "tac": "1234"},
+        )
+
         sdcore_management_relation_id = self.harness.add_relation(
             relation_name=SDCORE_MANAGEMENT_RELATION_NAME,
             remote_app=TEST_SDCORE_MANAGEMENT_PROVIDER_APP_NAME,
@@ -93,10 +143,44 @@ class TestCharm(unittest.TestCase):
             app_or_unit=TEST_SDCORE_MANAGEMENT_PROVIDER_APP_NAME,
             key_values={"management_url": "http://10.0.0.1:5000"},
         )
+
         self.harness.container_pebble_ready("nms")
         self.assertEqual(
             self.harness.model.unit.status,
             WaitingStatus("Waiting for UPF information to be available"),
+        )
+
+    def test_given_gnb_identity_information_not_available_when_pebble_ready_then_status_is_waiting(
+        self,
+    ):
+        fiveg_n4_relation_id = self.harness.add_relation(
+            relation_name=FIVEG_N4_RELATION_NAME,
+            remote_app=TEST_FIVEG_N4_PROVIDER_APP_NAME,
+        )
+        self.harness.update_relation_data(
+            relation_id=fiveg_n4_relation_id,
+            app_or_unit=TEST_FIVEG_N4_PROVIDER_APP_NAME,
+            key_values={"upf_hostname": "some.host.name", "upf_port": "1234"},
+        )
+        sdcore_management_relation_id = self.harness.add_relation(
+            relation_name=SDCORE_MANAGEMENT_RELATION_NAME,
+            remote_app=TEST_SDCORE_MANAGEMENT_PROVIDER_APP_NAME,
+        )
+        self.harness.update_relation_data(
+            relation_id=sdcore_management_relation_id,
+            app_or_unit=TEST_SDCORE_MANAGEMENT_PROVIDER_APP_NAME,
+            key_values={"management_url": "http://10.0.0.1:5000"},
+        )
+
+        self.harness.add_relation(
+            relation_name=GNB_IDENTITY_RELATION_NAME,
+            remote_app=TEST_GNB_IDENTITY_PROVIDER_APP_NAME,
+        )
+
+        self.harness.container_pebble_ready("nms")
+        self.assertEqual(
+            self.harness.model.unit.status,
+            WaitingStatus("Waiting for gNB identity to be available"),
         )
 
     def test_given_environment_information_available_and_required_relations_created_when_pebble_ready_then_pebble_plan_is_applied(  # noqa: E501
@@ -123,6 +207,16 @@ class TestCharm(unittest.TestCase):
             relation_id=sdcore_management_relation_id,
             app_or_unit=TEST_SDCORE_MANAGEMENT_PROVIDER_APP_NAME,
             key_values={"management_url": test_management_url},
+        )
+
+        gnb_identity_relation_id = self.harness.add_relation(
+            relation_name=GNB_IDENTITY_RELATION_NAME,
+            remote_app=TEST_GNB_IDENTITY_PROVIDER_APP_NAME,
+        )
+        self.harness.update_relation_data(
+            relation_id=gnb_identity_relation_id,
+            app_or_unit=TEST_GNB_IDENTITY_PROVIDER_APP_NAME,
+            key_values={"gnb_name": "some.gnb", "tac": "1234"},
         )
 
         expected_plan = {
@@ -166,6 +260,16 @@ class TestCharm(unittest.TestCase):
             relation_id=sdcore_management_relation_id,
             app_or_unit=TEST_SDCORE_MANAGEMENT_PROVIDER_APP_NAME,
             key_values={"management_url": "http://10.0.0.1:5000"},
+        )
+
+        gnb_identity_relation_id = self.harness.add_relation(
+            relation_name=GNB_IDENTITY_RELATION_NAME,
+            remote_app=TEST_GNB_IDENTITY_PROVIDER_APP_NAME,
+        )
+        self.harness.update_relation_data(
+            relation_id=gnb_identity_relation_id,
+            app_or_unit=TEST_GNB_IDENTITY_PROVIDER_APP_NAME,
+            key_values={"gnb_name": "some.gnb", "tac": "1234"},
         )
 
         self.assertEqual(self.harness.model.unit.status, ActiveStatus())

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -79,7 +79,7 @@ class TestCharm(unittest.TestCase):
         self.harness.container_pebble_ready("nms")
         self.assertEqual(self.harness.model.unit.status, ActiveStatus())
 
-    def test_given_n4_information_not_available_when_pebble_ready_then_status_is_waiting(self):
+    def test_given_n4_information_not_available_when_pebble_ready_then_status_is_active(self):
         sdcore_management_relation_id = self.harness.add_relation(
             relation_name=SDCORE_MANAGEMENT_RELATION_NAME,
             remote_app=TEST_SDCORE_MANAGEMENT_PROVIDER_APP_NAME,
@@ -96,66 +96,9 @@ class TestCharm(unittest.TestCase):
         )
 
         self.harness.container_pebble_ready("nms")
-        self.assertEqual(
-            self.harness.model.unit.status,
-            WaitingStatus("Waiting for UPF information to be available"),
-        )
+        self.assertEqual(self.harness.model.unit.status, ActiveStatus())
 
-    def test_given_n4_upf_hostname_not_available_when_pebble_ready_then_status_is_waiting(self):
-        sdcore_management_relation_id = self.harness.add_relation(
-            relation_name=SDCORE_MANAGEMENT_RELATION_NAME,
-            remote_app=TEST_SDCORE_MANAGEMENT_PROVIDER_APP_NAME,
-        )
-        self.harness.update_relation_data(
-            relation_id=sdcore_management_relation_id,
-            app_or_unit=TEST_SDCORE_MANAGEMENT_PROVIDER_APP_NAME,
-            key_values={"management_url": "http://10.0.0.1:5000"},
-        )
-
-        fiveg_n4_relation_id = self.harness.add_relation(
-            relation_name=FIVEG_N4_RELATION_NAME,
-            remote_app=TEST_FIVEG_N4_PROVIDER_APP_NAME,
-        )
-        self.harness.update_relation_data(
-            relation_id=fiveg_n4_relation_id,
-            app_or_unit=TEST_FIVEG_N4_PROVIDER_APP_NAME,
-            key_values={"upf_port": "1234"},
-        )
-
-        self.harness.container_pebble_ready("nms")
-        self.assertEqual(
-            self.harness.model.unit.status,
-            WaitingStatus("Waiting for UPF information to be available"),
-        )
-
-    def test_given_n4_upf_port_not_available_when_pebble_ready_then_status_is_waiting(self):
-        sdcore_management_relation_id = self.harness.add_relation(
-            relation_name=SDCORE_MANAGEMENT_RELATION_NAME,
-            remote_app=TEST_SDCORE_MANAGEMENT_PROVIDER_APP_NAME,
-        )
-        self.harness.update_relation_data(
-            relation_id=sdcore_management_relation_id,
-            app_or_unit=TEST_SDCORE_MANAGEMENT_PROVIDER_APP_NAME,
-            key_values={"management_url": "http://10.0.0.1:5000"},
-        )
-
-        fiveg_n4_relation_id = self.harness.add_relation(
-            relation_name=FIVEG_N4_RELATION_NAME,
-            remote_app=TEST_FIVEG_N4_PROVIDER_APP_NAME,
-        )
-        self.harness.update_relation_data(
-            relation_id=fiveg_n4_relation_id,
-            app_or_unit=TEST_FIVEG_N4_PROVIDER_APP_NAME,
-            key_values={"upf_hostname": "some.host.name"},
-        )
-
-        self.harness.container_pebble_ready("nms")
-        self.assertEqual(
-            self.harness.model.unit.status,
-            WaitingStatus("Waiting for UPF information to be available"),
-        )
-
-    def test_given_gnb_identity_information_not_available_when_pebble_ready_then_status_is_waiting(
+    def test_given_gnb_identity_information_not_available_when_pebble_ready_then_status_is_active(
         self,
     ):
         sdcore_management_relation_id = self.harness.add_relation(
@@ -174,12 +117,9 @@ class TestCharm(unittest.TestCase):
         )
 
         self.harness.container_pebble_ready("nms")
-        self.assertEqual(
-            self.harness.model.unit.status,
-            WaitingStatus("Waiting for gNB information to be available"),
-        )
+        self.assertEqual(self.harness.model.unit.status, ActiveStatus())
 
-    def test_given_gnb_identity_gnb_name_not_available_when_pebble_ready_then_status_is_waiting(
+    def test_given_gnb_identity_gnb_name_not_available_when_pebble_ready_then_status_is_active(
         self,
     ):
         sdcore_management_relation_id = self.harness.add_relation(
@@ -203,12 +143,9 @@ class TestCharm(unittest.TestCase):
         )
 
         self.harness.container_pebble_ready("nms")
-        self.assertEqual(
-            self.harness.model.unit.status,
-            WaitingStatus("Waiting for gNB information to be available"),
-        )
+        self.assertEqual(self.harness.model.unit.status, ActiveStatus())
 
-    def test_given_gnb_identity_tac_not_available_when_pebble_ready_then_status_is_waiting(
+    def test_given_gnb_identity_tac_not_available_when_pebble_ready_then_status_is_active(
         self,
     ):
         sdcore_management_relation_id = self.harness.add_relation(
@@ -232,12 +169,9 @@ class TestCharm(unittest.TestCase):
         )
 
         self.harness.container_pebble_ready("nms")
-        self.assertEqual(
-            self.harness.model.unit.status,
-            WaitingStatus("Waiting for gNB information to be available"),
-        )
+        self.assertEqual(self.harness.model.unit.status, ActiveStatus())
 
-    def test_given_gnb_identity_information_not_available_in_one_relation_when_pebble_ready_then_status_is_waiting(  # noqa: E501
+    def test_given_gnb_identity_information_not_available_in_one_relation_when_pebble_ready_then_status_is_active(  # noqa: E501
         self,
     ):
         sdcore_management_relation_id = self.harness.add_relation(
@@ -267,10 +201,7 @@ class TestCharm(unittest.TestCase):
         )
 
         self.harness.container_pebble_ready("nms")
-        self.assertEqual(
-            self.harness.model.unit.status,
-            WaitingStatus("Waiting for gNB information to be available"),
-        )
+        self.assertEqual(self.harness.model.unit.status, ActiveStatus())
 
     def test_given_all_relations_created_when_pebble_ready_then_pebble_plan_is_applied(self):
         test_upf_hostname = "some.host.name"

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -176,7 +176,7 @@ class TestCharm(unittest.TestCase):
         self.harness.container_pebble_ready("nms")
         self.assertEqual(
             self.harness.model.unit.status,
-            WaitingStatus("Waiting for gNB identity to be available"),
+            WaitingStatus("Waiting for gNB information to be available"),
         )
 
     def test_given_gnb_identity_gnb_name_not_available_when_pebble_ready_then_status_is_waiting(
@@ -205,7 +205,7 @@ class TestCharm(unittest.TestCase):
         self.harness.container_pebble_ready("nms")
         self.assertEqual(
             self.harness.model.unit.status,
-            WaitingStatus("Waiting for gNB identity to be available"),
+            WaitingStatus("Waiting for gNB information to be available"),
         )
 
     def test_given_gnb_identity_tac_not_available_when_pebble_ready_then_status_is_waiting(
@@ -234,7 +234,7 @@ class TestCharm(unittest.TestCase):
         self.harness.container_pebble_ready("nms")
         self.assertEqual(
             self.harness.model.unit.status,
-            WaitingStatus("Waiting for gNB identity to be available"),
+            WaitingStatus("Waiting for gNB information to be available"),
         )
 
     def test_given_gnb_identity_information_not_available_in_one_relation_when_pebble_ready_then_status_is_waiting(  # noqa: E501
@@ -269,7 +269,7 @@ class TestCharm(unittest.TestCase):
         self.harness.container_pebble_ready("nms")
         self.assertEqual(
             self.harness.model.unit.status,
-            WaitingStatus("Waiting for gNB identity to be available"),
+            WaitingStatus("Waiting for gNB information to be available"),
         )
 
     def test_given_all_relations_created_when_pebble_ready_then_pebble_plan_is_applied(self):


### PR DESCRIPTION
# Description

Implements the requirer side of the `fiveg_gnb_identity` interface. The  `fiveg_gnb_identity`  relation is not mandatory.
At the moment we get the information from the relation databag but we do not do anything with it. 
Storage of relation data in config file is going to be done in a separate PR.

Check over the presence of `fiveg_n4` relation was removed since it's not mandatory either.
At the moment the `fiveg_n4` relation is limited to one. Implementation of multiple `fiveg_n4` relations  is going to be done in a separate PR.


Reference:
https://docs.google.com/document/d/1s3U82GTUZFJ9mEhiHig0oAl44F0fq3eQT2PNv1uV75g/edit

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of the library