### PR TITLE
docs: Adds Charmhub badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-# sdcore-nms-operator
+# SD-Core NMS Operator (k8s)
+[![CharmHub Badge](https://charmhub.io/sdcore-nms/badge.svg)](https://charmhub.io/sdcore-nms)
 
-Charmed Operator for SD-Core's NMS.
+Charmed Operator for the SD-Core Network Management System (NMS).
 
 ## Usage
 


### PR DESCRIPTION
# Description

The Telco charms currently have broken statuses in the [charm engineering page](https://releases.juju.is/?team=Telco). This PR fixes this issues and brings the README.md in line with the other team's (ex. [Grafana K8s Operator](https://github.com/canonical/grafana-k8s-operator)).

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library