### PR TITLE
fix: integration tests failure

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -112,8 +112,8 @@ async def get_traefik_ip(ops_test) -> str:
 
 
 def _get_host_from_url(url: str) -> str:
-    """Returns the host from a URL formatted as http://<host>:<port>."""
-    return url.split("//")[1].split(":")[0]
+    """Returns the host from a URL formatted as http://<host>:<port>/."""
+    return url.split("//")[1].split(":")[0].split("/")[0]
 
 
 def ui_is_running(ip: str, host: str) -> bool:
@@ -128,8 +128,8 @@ def ui_is_running(ip: str, host: str) -> bool:
             response.raise_for_status()
             if "5G NMS" in response.content.decode("utf-8"):
                 return True
-        except Exception:
-            logger.info("UI is not running yet")
+        except Exception as e:
+            logger.info(f"UI is not running yet: {e}")
         time.sleep(2)
     return False
 

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -112,7 +112,7 @@ async def get_traefik_ip(ops_test) -> str:
 
 
 def _get_host_from_url(url: str) -> str:
-    """Returns the host from a URL formatted as http://<host>:<port>/."""
+    """Returns the host from a URL formatted as http://<host>:<port>/ or as http://<host>/."""
     return url.split("//")[1].split(":")[0].split("/")[0]
 
 


### PR DESCRIPTION
# Description

This is a fix for the integration test failure.
The reason was a 400 bad request due to an invalid header. The host used in the header contained a `/` at the end.
This is due to a change in the `show-proxied-endpoints` action from traefik. 
Before we used to get :  `"url": "http://test-traefik-sdcore-nms.pizza.com:80/"` 
And now we are getting:  `"url": "http://old-traefik-sdcore-nms.pizza.com/)"`
The observability team has not clarified if this change is expected.

The solution works in case we either get the port or not in the action result. 

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library