### PR TITLE
feat: Creates basic gnb/upf config files when no relation is created

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -101,38 +101,33 @@ class SDCoreNMSOperatorCharm(CharmBase):
             self._container.restart(self._service_name)
 
     def _configure_upf_information(self) -> None:
-        """The `fiveg_n4` relation is not mandatory.
+        """Creates the UPF config file.
 
-        If it exists, config files are generated and pushed to the workload.
+        The config file is generated based on the various `fiveg_n4` relations and their content.
         """
         if not self.model.relations.get(FIVEG_N4_RELATION_NAME):
             logger.info("Relation %s not available", FIVEG_N4_RELATION_NAME)
-            return
         upf_existing_content = self._get_existing_config_file(path=UPF_CONFIG_PATH)
         upf_config_content = self._get_upf_config()
-        if not upf_config_content:
-            logger.error("UPF config file is invalid")
-            return
         if not upf_existing_content or not config_file_content_matches(
-            existing_content=upf_existing_content, new_content=upf_config_content
+            existing_content=upf_existing_content,
+            new_content=upf_config_content,
         ):
             self._push_upf_config_file_to_workload(upf_config_content)
 
     def _configure_gnb_information(self) -> None:
-        """The `fiveg_gnb_identity` relation is not mandatory.
+        """Creates the GNB config file.
 
-        If it exists, config files are generated and pushed to the workload.
+        The config file is generated based on the various `fiveg_gnb_identity` relations
+        and their content.
         """
         if not self.model.relations.get(GNB_IDENTITY_RELATION_NAME):
             logger.info("Relation %s not available", GNB_IDENTITY_RELATION_NAME)
-            return
         gnb_existing_content = self._get_existing_config_file(path=GNB_CONFIG_PATH)
         gnb_config_content = self._get_gnb_config()
-        if not gnb_config_content:
-            logger.error("gNB config file is invalid")
-            return
         if not gnb_existing_content or not config_file_content_matches(
-            existing_content=gnb_existing_content, new_content=gnb_config_content
+            existing_content=gnb_existing_content,
+            new_content=gnb_config_content,
         ):
             self._push_gnb_config_file_to_workload(gnb_config_content)
 
@@ -160,7 +155,8 @@ class SDCoreNMSOperatorCharm(CharmBase):
         for fiveg_n4_relation in self.model.relations.get(FIVEG_N4_RELATION_NAME, []):
             if not fiveg_n4_relation.app:
                 logger.warning(
-                    "Application missing from the %s relation data", FIVEG_N4_RELATION_NAME
+                    "Application missing from the %s relation data",
+                    FIVEG_N4_RELATION_NAME,
                 )
                 return []
             port = fiveg_n4_relation.data[fiveg_n4_relation.app].get("upf_port", "")
@@ -200,10 +196,12 @@ class SDCoreNMSOperatorCharm(CharmBase):
 
         upf_config = []
         for upf_hostname, upf_port in upf_host_port_list:
-            upf_config_entry = {"hostname": upf_hostname, "port": str(upf_port)}
+            upf_config_entry = {
+                "hostname": upf_hostname,
+                "port": str(upf_port),
+            }
             upf_config.append(upf_config_entry)
-
-        return "" if not upf_config else json.dumps(upf_config, sort_keys=True)
+        return json.dumps(upf_config, sort_keys=True)
 
     def _get_gnb_config(self) -> str:
         """Gets the GNB configuration for the NMS in a json format.
@@ -219,7 +217,7 @@ class SDCoreNMSOperatorCharm(CharmBase):
             gnb_conf_entry = {"name": gnb_name, "tac": str(gnb_tac)}
             gnb_config.append(gnb_conf_entry)
 
-        return "" if not gnb_config else json.dumps(gnb_config, sort_keys=True)
+        return json.dumps(gnb_config, sort_keys=True)
 
     def _push_upf_config_file_to_workload(self, content: str):
         """Push the upf config files to the NMS workload."""

--- a/src/charm.py
+++ b/src/charm.py
@@ -158,7 +158,7 @@ class SDCoreNMSOperatorCharm(CharmBase):
                     "Application missing from the %s relation data",
                     FIVEG_N4_RELATION_NAME,
                 )
-                return []
+                continue
             port = fiveg_n4_relation.data[fiveg_n4_relation.app].get("upf_port", "")
             hostname = fiveg_n4_relation.data[fiveg_n4_relation.app].get("upf_hostname", "")
             if hostname and port:
@@ -178,7 +178,7 @@ class SDCoreNMSOperatorCharm(CharmBase):
                     "Application missing from the %s relation data",
                     GNB_IDENTITY_RELATION_NAME,
                 )
-                return []
+                continue
             gnb_name = gnb_identity_relation.data[gnb_identity_relation.app].get("gnb_name", "")
             gnb_tac = gnb_identity_relation.data[gnb_identity_relation.app].get("tac", "")
             if gnb_name and gnb_tac:

--- a/tests/unit/expected_gnb.json
+++ b/tests/unit/expected_gnb.json
@@ -1,0 +1,6 @@
+[
+    {
+        "name": "some.gnb.name",
+        "tac": "1234"
+    }
+]

--- a/tests/unit/expected_upf.json
+++ b/tests/unit/expected_upf.json
@@ -1,0 +1,6 @@
+[
+    {
+        "hostname": "some.host.name",
+        "port": "1234"
+    }
+]

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -3,7 +3,6 @@
 
 import json
 import unittest
-from io import StringIO
 from unittest.mock import Mock, patch
 
 from ops import testing
@@ -19,6 +18,20 @@ GNB_IDENTITY_RELATION_NAME = "fiveg_gnb_identity"
 TEST_GNB_IDENTITY_PROVIDER_APP_NAME = "fiveg_gnb_identity_provider_app"
 TEST_UPF_CONFIG_PATH = "/nms/config/upf_config.json"
 TEST_GNB_CONFIG_PATH = "/nms/config/gnb_config.json"
+
+
+def read_file(path: str) -> str:
+    """Reads a file and returns as a string.
+
+    Args:
+        path (str): path to the file.
+
+    Returns:
+        str: content of the file.
+    """
+    with open(path, "r") as f:
+        content = f.read()
+    return content
 
 
 class TestCharm(unittest.TestCase):
@@ -71,6 +84,8 @@ class TestCharm(unittest.TestCase):
         )
 
     def test_given_management_url_available_when_pebble_ready_then_status_is_active(self):
+        root = self.harness.get_filesystem_root("nms")
+        (root / "nms/config/").mkdir(parents=True)
         sdcore_management_relation_id = self.harness.add_relation(
             relation_name=SDCORE_MANAGEMENT_RELATION_NAME,
             remote_app=TEST_SDCORE_MANAGEMENT_PROVIDER_APP_NAME,
@@ -83,11 +98,11 @@ class TestCharm(unittest.TestCase):
         self.harness.container_pebble_ready("nms")
         self.assertEqual(self.harness.model.unit.status, ActiveStatus())
 
-    @patch("ops.model.Container.push")
     def test_given_n4_information_not_available_when_pebble_ready_then_status_is_active(
         self,
-        _,
     ):
+        root = self.harness.get_filesystem_root("nms")
+        (root / "nms/config/").mkdir(parents=True)
         sdcore_management_relation_id = self.harness.add_relation(
             relation_name=SDCORE_MANAGEMENT_RELATION_NAME,
             remote_app=TEST_SDCORE_MANAGEMENT_PROVIDER_APP_NAME,
@@ -106,11 +121,11 @@ class TestCharm(unittest.TestCase):
         self.harness.container_pebble_ready("nms")
         self.assertEqual(self.harness.model.unit.status, ActiveStatus())
 
-    @patch("ops.model.Container.push")
     def test_given_gnb_identity_information_not_available_when_pebble_ready_then_status_is_active(
         self,
-        _,
     ):
+        root = self.harness.get_filesystem_root("nms")
+        (root / "nms/config/").mkdir(parents=True)
         sdcore_management_relation_id = self.harness.add_relation(
             relation_name=SDCORE_MANAGEMENT_RELATION_NAME,
             remote_app=TEST_SDCORE_MANAGEMENT_PROVIDER_APP_NAME,
@@ -129,11 +144,11 @@ class TestCharm(unittest.TestCase):
         self.harness.container_pebble_ready("nms")
         self.assertEqual(self.harness.model.unit.status, ActiveStatus())
 
-    @patch("ops.model.Container.push")
     def test_given_gnb_identity_gnb_name_not_available_when_pebble_ready_then_status_is_active(
         self,
-        _,
     ):
+        root = self.harness.get_filesystem_root("nms")
+        (root / "nms/config/").mkdir(parents=True)
         sdcore_management_relation_id = self.harness.add_relation(
             relation_name=SDCORE_MANAGEMENT_RELATION_NAME,
             remote_app=TEST_SDCORE_MANAGEMENT_PROVIDER_APP_NAME,
@@ -157,11 +172,11 @@ class TestCharm(unittest.TestCase):
         self.harness.container_pebble_ready("nms")
         self.assertEqual(self.harness.model.unit.status, ActiveStatus())
 
-    @patch("ops.model.Container.push")
     def test_given_gnb_identity_tac_not_available_when_pebble_ready_then_status_is_active(
         self,
-        _,
     ):
+        root = self.harness.get_filesystem_root("nms")
+        (root / "nms/config/").mkdir(parents=True)
         sdcore_management_relation_id = self.harness.add_relation(
             relation_name=SDCORE_MANAGEMENT_RELATION_NAME,
             remote_app=TEST_SDCORE_MANAGEMENT_PROVIDER_APP_NAME,
@@ -185,11 +200,11 @@ class TestCharm(unittest.TestCase):
         self.harness.container_pebble_ready("nms")
         self.assertEqual(self.harness.model.unit.status, ActiveStatus())
 
-    @patch("ops.model.Container.push")
     def test_given_gnb_identity_information_not_available_in_one_relation_when_pebble_ready_then_status_is_active(  # noqa: E501
         self,
-        _,
     ):
+        root = self.harness.get_filesystem_root("nms")
+        (root / "nms/config/").mkdir(parents=True)
         sdcore_management_relation_id = self.harness.add_relation(
             relation_name=SDCORE_MANAGEMENT_RELATION_NAME,
             remote_app=TEST_SDCORE_MANAGEMENT_PROVIDER_APP_NAME,
@@ -219,11 +234,11 @@ class TestCharm(unittest.TestCase):
         self.harness.container_pebble_ready("nms")
         self.assertEqual(self.harness.model.unit.status, ActiveStatus())
 
-    @patch("ops.model.Container.push")
     def test_given_all_relations_created_when_pebble_ready_then_pebble_plan_is_applied(
         self,
-        _,
     ):
+        root = self.harness.get_filesystem_root("nms")
+        (root / "nms/config/").mkdir(parents=True)
         test_upf_hostname = "some.host.name"
         test_upf_port = "1234"
         test_management_url = "http://10.0.0.1:5000"
@@ -276,11 +291,11 @@ class TestCharm(unittest.TestCase):
 
         self.assertEqual(expected_plan, updated_plan)
 
-    @patch("ops.model.Container.push")
     def test_given_required_relations_created_without_fiveg_n4_relation_when_pebble_ready_then_pebble_plan_is_applied(  # noqa: E501
         self,
-        _,
     ):
+        root = self.harness.get_filesystem_root("nms")
+        (root / "nms/config/").mkdir(parents=True)
         test_management_url = "http://10.0.0.1:5000"
 
         sdcore_management_relation_id = self.harness.add_relation(
@@ -312,11 +327,11 @@ class TestCharm(unittest.TestCase):
 
         self.assertEqual(expected_plan, updated_plan)
 
-    @patch("ops.model.Container.push")
     def test_given_environment_information_available_all_relations_created_when_pebble_ready_then_status_is_active(  # noqa: E501
         self,
-        _,
     ):
+        root = self.harness.get_filesystem_root("nms")
+        (root / "nms/config/").mkdir(parents=True)
         self.harness.set_can_connect(container="nms", val=True)
         fiveg_n4_relation_id = self.harness.add_relation(
             relation_name=FIVEG_N4_RELATION_NAME,
@@ -350,11 +365,11 @@ class TestCharm(unittest.TestCase):
 
         self.assertEqual(self.harness.model.unit.status, ActiveStatus())
 
-    @patch("ops.model.Container.push")
     def test_given_n4_information_available_when_pebble_ready_then_upf_config_generated_and_pushed(  # noqa: E501
         self,
-        patch_push,
     ):
+        root = self.harness.get_filesystem_root("nms")
+        (root / "nms/config/").mkdir(parents=True)
         expected_upf_config = [
             {
                 "hostname": "some.host.name",
@@ -393,16 +408,18 @@ class TestCharm(unittest.TestCase):
             app_or_unit=TEST_SDCORE_MANAGEMENT_PROVIDER_APP_NAME,
             key_values={"management_url": "http://10.0.0.1:5000"},
         )
+
         self.harness.container_pebble_ready("nms")
-        patch_push.assert_called_with(
-            path=TEST_UPF_CONFIG_PATH, source=json.dumps(expected_upf_config)
+
+        self.assertEqual(
+            json.loads((root / "nms/config/upf_config.json").read_text()), expected_upf_config
         )
 
-    @patch("ops.model.Container.push")
     def test_given_gnb_identity_information_available_when_pebble_ready_then_gnb_config_generated_and_pushed(  # noqa: E501
         self,
-        patch_push,
     ):
+        root = self.harness.get_filesystem_root("nms")
+        (root / "nms/config/").mkdir(parents=True)
         expected_gnb_config = [
             {
                 "name": "some.gnb",
@@ -427,28 +444,20 @@ class TestCharm(unittest.TestCase):
             app_or_unit=TEST_SDCORE_MANAGEMENT_PROVIDER_APP_NAME,
             key_values={"management_url": "http://10.0.0.1:5000"},
         )
+
         self.harness.container_pebble_ready("nms")
-        patch_push.assert_called_with(
-            path=TEST_GNB_CONFIG_PATH, source=json.dumps(expected_gnb_config)
+
+        self.assertEqual(
+            json.loads((root / "nms/config/gnb_config.json").read_text()), expected_gnb_config
         )
 
-    @patch("ops.model.Container.push")
-    @patch("ops.model.Container.exists")
-    @patch("ops.model.Container.pull")
-    def test_given_gnb_config_already_pushed_and_content_matches_when_pebble_ready_then_gnb_config_is_not_pushed(  # noqa: E501
+    def test_given_gnb_config_already_pushed_and_content_matches_when_pebble_ready_then_gnb_config_is_not_changed(  # noqa: E501
         self,
-        patch_pull,
-        patch_exists,
-        patch_push,
     ):
-        expected_gnb_config = [
-            {
-                "name": "some.gnb",
-                "tac": "1234",
-            }
-        ]
-        patch_exists.return_value = True
-        patch_pull.return_value = StringIO(json.dumps(expected_gnb_config))
+        root = self.harness.get_filesystem_root("nms")
+        (root / "nms/config/").mkdir(parents=True)
+        expected_gnb_content = read_file("tests/unit/expected_gnb.json")
+        (root / "nms/config/upf_config.json").write_text(expected_gnb_content)
 
         gnb_identity_relation_id = self.harness.add_relation(
             relation_name=GNB_IDENTITY_RELATION_NAME,
@@ -457,7 +466,7 @@ class TestCharm(unittest.TestCase):
         self.harness.update_relation_data(
             relation_id=gnb_identity_relation_id,
             app_or_unit=TEST_GNB_IDENTITY_PROVIDER_APP_NAME,
-            key_values={"gnb_name": "some.gnb", "tac": "1234"},
+            key_values={"gnb_name": "some.gnb.name", "tac": "1234"},
         )
         sdcore_management_relation_id = self.harness.add_relation(
             relation_name=SDCORE_MANAGEMENT_RELATION_NAME,
@@ -468,26 +477,57 @@ class TestCharm(unittest.TestCase):
             app_or_unit=TEST_SDCORE_MANAGEMENT_PROVIDER_APP_NAME,
             key_values={"management_url": "http://10.0.0.1:5000"},
         )
-        self.harness.container_pebble_ready("nms")
-        patch_push.assert_not_called()
 
-    @patch("ops.model.Container.push")
-    @patch("ops.model.Container.exists")
-    @patch("ops.model.Container.pull")
-    def test_given_upf_config_already_pushed_and_content_matches_when_pebble_ready_then_upf_config_is_not_pushed(  # noqa: E501
+        self.harness.container_pebble_ready("nms")
+
+        self.assertEqual(
+            json.loads((root / "nms/config/gnb_config.json").read_text()),
+            json.loads(expected_gnb_content),
+        )
+
+    def test_given_no_n4_relation_when_pebble_ready_then_config_file_pushed(self):
+        self.harness.set_can_connect(container="nms", val=True)
+        root = self.harness.get_filesystem_root("nms")
+        (root / "nms/config/").mkdir(parents=True)
+        sdcore_management_relation_id = self.harness.add_relation(
+            relation_name=SDCORE_MANAGEMENT_RELATION_NAME,
+            remote_app=TEST_SDCORE_MANAGEMENT_PROVIDER_APP_NAME,
+        )
+        self.harness.update_relation_data(
+            relation_id=sdcore_management_relation_id,
+            app_or_unit=TEST_SDCORE_MANAGEMENT_PROVIDER_APP_NAME,
+            key_values={"management_url": "http://10.0.0.1:5000"},
+        )
+
+        self.harness.container_pebble_ready("nms")
+
+        self.assertEqual((root / "nms/config/upf_config.json").read_text(), "[]")
+
+    def test_given_no_gnb_relation_when_pebble_ready_then_config_file_pushed(self):
+        self.harness.set_can_connect(container="nms", val=True)
+        root = self.harness.get_filesystem_root("nms")
+        (root / "nms/config/").mkdir(parents=True)
+        sdcore_management_relation_id = self.harness.add_relation(
+            relation_name=SDCORE_MANAGEMENT_RELATION_NAME,
+            remote_app=TEST_SDCORE_MANAGEMENT_PROVIDER_APP_NAME,
+        )
+        self.harness.update_relation_data(
+            relation_id=sdcore_management_relation_id,
+            app_or_unit=TEST_SDCORE_MANAGEMENT_PROVIDER_APP_NAME,
+            key_values={"management_url": "http://10.0.0.1:5000"},
+        )
+
+        self.harness.container_pebble_ready("nms")
+
+        self.assertEqual((root / "nms/config/gnb_config.json").read_text(), "[]")
+
+    def test_given_upf_config_already_pushed_and_content_matches_when_pebble_ready_then_upf_config_is_not_changed(  # noqa: E501
         self,
-        patch_pull,
-        patch_exists,
-        patch_push,
     ):
-        expected_upf_config = [
-            {
-                "hostname": "some.host.name",
-                "port": "1234",
-            }
-        ]
-        patch_exists.return_value = True
-        patch_pull.return_value = StringIO(json.dumps(expected_upf_config))
+        root = self.harness.get_filesystem_root("nms")
+        (root / "nms/config/").mkdir(parents=True)
+        expected_upf_content = read_file("tests/unit/expected_upf.json")
+        (root / "nms/config/upf_config.json").write_text(expected_upf_content)
 
         fiveg_n4_relation_id = self.harness.add_relation(
             relation_name=FIVEG_N4_RELATION_NAME,
@@ -508,23 +548,17 @@ class TestCharm(unittest.TestCase):
             key_values={"management_url": "http://10.0.0.1:5000"},
         )
         self.harness.container_pebble_ready("nms")
-        patch_push.assert_not_called()
 
-    @patch("ops.model.Container.push")
-    @patch("ops.model.Container.exists")
-    @patch("ops.model.Container.pull")
+        self.assertEqual((root / "nms/config/upf_config.json").read_text(), expected_upf_content)
+
     def test_given_upf_config_already_pushed_and_content_changes_when_pebble_ready_then_upf_config_is_pushed(  # noqa: E501
         self,
-        patch_pull,
-        patch_exists,
-        patch_push,
     ):
-        existing_upf_config = [
-            {
-                "hostname": "some.host.name",
-                "port": "1234",
-            }
-        ]
+        root = self.harness.get_filesystem_root("nms")
+        (root / "nms/config/").mkdir(parents=True)
+        existing_upf_config = read_file("tests/unit/expected_upf.json")
+        (root / "nms/config/upf_config.json").write_text(existing_upf_config)
+
         expected_upf_config = [
             {
                 "hostname": "some.host.name",
@@ -535,8 +569,6 @@ class TestCharm(unittest.TestCase):
                 "port": "4567",
             },
         ]
-        patch_exists.return_value = True
-        patch_pull.return_value = StringIO(json.dumps(existing_upf_config))
 
         fiveg_n4_relation_1_id = self.harness.add_relation(
             relation_name=FIVEG_N4_RELATION_NAME,
@@ -566,25 +598,18 @@ class TestCharm(unittest.TestCase):
             key_values={"management_url": "http://10.0.0.1:5000"},
         )
         self.harness.container_pebble_ready("nms")
-        patch_push.assert_called_with(
-            path=TEST_UPF_CONFIG_PATH, source=json.dumps(expected_upf_config)
+
+        self.assertEqual(
+            json.loads((root / "nms/config/upf_config.json").read_text()), expected_upf_config
         )
 
-    @patch("ops.model.Container.push")
-    @patch("ops.model.Container.exists")
-    @patch("ops.model.Container.pull")
     def test_given_gnb_config_already_pushed_and_content_changes_when_pebble_ready_then_gnb_config_is_pushed(  # noqa: E501
         self,
-        patch_pull,
-        patch_exists,
-        patch_push,
     ):
-        existing_gnb_config = [
-            {
-                "name": "some.gnb.name",
-                "tac": "1234",
-            }
-        ]
+        root = self.harness.get_filesystem_root("nms")
+        (root / "nms/config/").mkdir(parents=True)
+        existing_gnb_config = read_file("tests/unit/expected_gnb.json")
+        (root / "nms/config/upf_config.json").write_text(existing_gnb_config)
         expected_gnb_config = [
             {
                 "name": "some.gnb.name",
@@ -595,8 +620,6 @@ class TestCharm(unittest.TestCase):
                 "tac": "4567",
             },
         ]
-        patch_exists.return_value = True
-        patch_pull.return_value = StringIO(json.dumps(existing_gnb_config))
 
         gnb_identity_relation_1_id = self.harness.add_relation(
             relation_name=GNB_IDENTITY_RELATION_NAME,
@@ -625,51 +648,9 @@ class TestCharm(unittest.TestCase):
             app_or_unit=TEST_SDCORE_MANAGEMENT_PROVIDER_APP_NAME,
             key_values={"management_url": "http://10.0.0.1:5000"},
         )
-        self.harness.container_pebble_ready("nms")
-        patch_push.assert_called_with(
-            path=TEST_GNB_CONFIG_PATH, source=json.dumps(expected_gnb_config)
-        )
 
-    @patch("ops.model.Container.push")
-    def test_given_n4_information_not_available_in_relation_data_when_pebble_ready_then_upf_config_not_pushed(  # noqa: E501
-        self,
-        patch_push,
-    ):
-        self.harness.set_can_connect(container="nms", val=True)
-        self.harness.add_relation(
-            relation_name=FIVEG_N4_RELATION_NAME,
-            remote_app=TEST_FIVEG_N4_PROVIDER_APP_NAME,
-        )
-        sdcore_management_relation_id = self.harness.add_relation(
-            relation_name=SDCORE_MANAGEMENT_RELATION_NAME,
-            remote_app=TEST_SDCORE_MANAGEMENT_PROVIDER_APP_NAME,
-        )
-        self.harness.update_relation_data(
-            relation_id=sdcore_management_relation_id,
-            app_or_unit=TEST_SDCORE_MANAGEMENT_PROVIDER_APP_NAME,
-            key_values={"management_url": "http://10.0.0.1:5000"},
-        )
         self.harness.container_pebble_ready("nms")
-        patch_push.assert_not_called()
 
-    @patch("ops.model.Container.push")
-    def test_given_gnb_information_not_available_in_relation_data_when_pebble_ready_then_gnb_config_not_pushed(  # noqa: E501
-        self,
-        patch_push,
-    ):
-        self.harness.set_can_connect(container="nms", val=True)
-        self.harness.add_relation(
-            relation_name=GNB_IDENTITY_RELATION_NAME,
-            remote_app=TEST_GNB_IDENTITY_PROVIDER_APP_NAME,
+        self.assertEqual(
+            json.loads((root / "nms/config/gnb_config.json").read_text()), expected_gnb_config
         )
-        sdcore_management_relation_id = self.harness.add_relation(
-            relation_name=SDCORE_MANAGEMENT_RELATION_NAME,
-            remote_app=TEST_SDCORE_MANAGEMENT_PROVIDER_APP_NAME,
-        )
-        self.harness.update_relation_data(
-            relation_id=sdcore_management_relation_id,
-            app_or_unit=TEST_SDCORE_MANAGEMENT_PROVIDER_APP_NAME,
-            key_values={"management_url": "http://10.0.0.1:5000"},
-        )
-        self.harness.container_pebble_ready("nms")
-        patch_push.assert_not_called()


### PR DESCRIPTION
# Description

Currently, if there are no Juju integrations between the nms operator and gnb/upf, the NMS would crash because there would be no gnb/upf config file. This PR here makes it so that a very basic config file containing nothing is created even if those relations do not exist. We also take advantage of this opportunity to get rid of all the patches made to filesystem operations in unit tests.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library