### PR TITLE
fix: Removing unittest.mock.patch from imports in test_charm.py

### DIFF
--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -3,7 +3,7 @@
 
 import json
 import unittest
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 from ops import testing
 from ops.model import ActiveStatus, BlockedStatus, WaitingStatus


### PR DESCRIPTION
# Description

Removes unused unittest.mock.patch from imports in test_charm.py

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of the library