### PR TITLE
fix: Pinning pytest-asyncio to 0.21.1

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -8,6 +8,7 @@ mypy
 pep8-naming
 pyproject-flake8
 pytest
+pytest-asyncio==0.21.1
 pytest-operator
 requests
 types-PyYAML


### PR DESCRIPTION
# Description

Pins the version of pytest-asyncio to 0.21.1.
Context: Latest version of pytest-asyncio removes asyncio_event_loop. This makes integration tests hang forever.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library