### PR TITLE
fix: Revert "chore(deps): update dependency pytest-asyncio to v0.23.2"

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -8,7 +8,7 @@ mypy
 pep8-naming
 pyproject-flake8
 pytest
-pytest-asyncio==0.23.2
+pytest-asyncio==0.21.1
 pytest-operator
 requests
 types-PyYAML


### PR DESCRIPTION
Reverts canonical/sdcore-nms-operator#32