### PR TITLE
chore: Rename SD-Core charms by adding -k8s as a suffix

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -25,7 +25,7 @@ jobs:
   integration-test:
     uses: canonical/sdcore-github-workflows/.github/workflows/integration-test-with-multus.yaml@main
     with:
-      charm-file-name: "sdcore-nms_ubuntu-22.04-amd64.charm"
+      charm-file-name: "sdcore-nms-k8s_ubuntu-22.04-amd64.charm"
 
   publish-charm:
     name: Publish Charm
@@ -37,5 +37,5 @@ jobs:
     if: ${{ github.ref_name == 'main' }}
     uses: canonical/sdcore-github-workflows/.github/workflows/publish-charm.yaml@main
     with:
-      charm-file-name: "sdcore-nms_ubuntu-22.04-amd64.charm"
+      charm-file-name: "sdcore-nms-k8s_ubuntu-22.04-amd64.charm"
     secrets: inherit

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# SD-Core NMS Operator for K8s
+# SD-Core NMS Operator (k8s)
 [![CharmHub Badge](https://charmhub.io/sdcore-nms-k8s/badge.svg)](https://charmhub.io/sdcore-nms-k8s)
 
 Charmed Operator for the SD-Core Network Management System (NMS) for K8s.

--- a/README.md
+++ b/README.md
@@ -1,30 +1,30 @@
-# SD-Core NMS Operator (k8s)
-[![CharmHub Badge](https://charmhub.io/sdcore-nms/badge.svg)](https://charmhub.io/sdcore-nms)
+# SD-Core NMS Operator for K8s
+[![CharmHub Badge](https://charmhub.io/sdcore-nms-k8s/badge.svg)](https://charmhub.io/sdcore-nms-k8s)
 
-Charmed Operator for the SD-Core Network Management System (NMS).
+Charmed Operator for the SD-Core Network Management System (NMS) for K8s.
 
 ## Usage
 
 ```bash
-juju deploy sdcore-nms --channel=edge
+juju deploy sdcore-nms-k8s --channel=edge
 ```
 
 ## Integrate
 
 ```bash
 juju deploy traefik-k8s --trust --config external_hostname=<your hostname> --config routing_mode=subdomain
-juju deploy sdcore-upf --channel=edge --trust
+juju deploy sdcore-upf-k8s --channel=edge --trust
 juju deploy mongodb-k8s --trust --channel=5/edge
-juju deploy sdcore-webui --channel=edge
-juju deploy sdcore-gnbsim --trust --channel=edge
-juju integrate mongodb-k8s sdcore-webui
-juju integrate sdcore-nms:ingress traefik-k8s:ingress
-juju integrate sdcore-nms:fiveg_n4 sdcore-upf:fiveg_n4
-juju integrate sdcore-nms:sdcore-management sdcore-webui:sdcore-management
-juju integrate sdcore-nms:fiveg_gnb_identity sdcore-gnbsim:fiveg_gnb_identity
+juju deploy sdcore-webui-k8s --channel=edge
+juju deploy sdcore-gnbsim-k8s --trust --channel=edge
+juju integrate mongodb-k8s sdcore-webui-k8s
+juju integrate sdcore-nms-k8s:ingress traefik-k8s:ingress
+juju integrate sdcore-nms-k8s:fiveg_n4 sdcore-upf-k8s:fiveg_n4
+juju integrate sdcore-nms-k8s:sdcore-management sdcore-webui-k8s:sdcore-management
+juju integrate sdcore-nms-k8s:fiveg_gnb_identity sdcore-gnbsim-k8s:fiveg_gnb_identity
 ```
 
-You should now be able to access the NMS at `https://<model name>-sdcore-nms.<your hostname>`
+You should now be able to access the NMS at `https://<model name>-sdcore-nms-k8s.<your hostname>`
 
 ## Image
 

--- a/lib/charms/sdcore_gnbsim_k8s/v0/fiveg_gnb_identity.py
+++ b/lib/charms/sdcore_gnbsim_k8s/v0/fiveg_gnb_identity.py
@@ -12,7 +12,7 @@ To get started using the library, you need to fetch the library using `charmcraf
 
 ```shell
 cd some-charm
-charmcraft fetch-lib charms.sdcore_gnbsim.v0.fiveg_gnb_identity
+charmcraft fetch-lib charms.sdcore_gnbsim_k8s.v0.fiveg_gnb_identity
 ```
 
 Add the following libraries to the charm's `requirements.txt` file:
@@ -24,7 +24,7 @@ Typical usage of this class would look something like:
 
     ```python
     ...
-    from charms.sdcore_gnbsim.v0.fiveg_gnb_identity import GnbIdentityProvides
+    from charms.sdcore_gnbsim_k8s.v0.fiveg_gnb_identity import GnbIdentityProvides
     ...
 
     class SomeProviderCharm(CharmBase):
@@ -56,7 +56,7 @@ Typical usage of this class would look something like:
 
     ```python
     ...
-    from charms.sdcore_gnbsim.v0.fiveg_gnb_identity import GnbIdentityRequires
+    from charms.sdcore_gnbsim_k8s.v0.fiveg_gnb_identity import GnbIdentityRequires
     ...
 
     class SomeRequirerCharm(CharmBase):
@@ -65,7 +65,7 @@ Typical usage of this class would look something like:
             ...
             self.fiveg_gnb_identity = GnbIdentityRequires(charm=self, relation_name="fiveg_gnb_identity")
             ...
-            self.framework.observe(self.fiveg_gnb_identity.on.fiveg_gnb_identity_available, 
+            self.framework.observe(self.fiveg_gnb_identity.on.fiveg_gnb_identity_available,
                 self._on_fiveg_gnb_identity_available)
 
         def _on_fiveg_gnb_identity_available(self, event):
@@ -90,7 +90,7 @@ from ops.framework import EventBase, EventSource, Handle, Object
 from pydantic import BaseModel, Field, ValidationError
 
 # The unique Charmhub library identifier, never change it
-LIBID = "ca9a66c5806e47e7b2750e8cdf696b80"
+LIBID = "fdef465e3dc143cfb805ec074673a7e9"
 
 # Increment this major API version when introducing breaking changes
 LIBAPI = 0
@@ -100,7 +100,6 @@ LIBAPI = 0
 LIBPATCH = 1
 
 PYDEPS = ["pydantic", "pytest-interface-tester"]
-
 
 logger = logging.getLogger(__name__)
 
@@ -134,6 +133,7 @@ class FivegGnbIdentityProviderAppData(BaseModel):
         examples=[1]
     )
 
+
 class ProviderSchema(DataBagSchema):
     """Provider schema for fiveg_gnb_identity."""
 
@@ -162,7 +162,7 @@ class FivegGnbIdentityRequestEvent(EventBase):
 
     def __init__(self, handle: Handle, relation_id: int):
         """Sets relation id.
-        
+
         Args:
             handle (Handle): Juju framework handle.
             relation_id : ID of the relation.
@@ -172,7 +172,7 @@ class FivegGnbIdentityRequestEvent(EventBase):
 
     def snapshot(self) -> dict:
         """Returns event data.
-        
+
         Returns:
             (dict): contains the relation ID.
         """
@@ -182,7 +182,7 @@ class FivegGnbIdentityRequestEvent(EventBase):
 
     def restore(self, snapshot: dict) -> None:
         """Restores event data.
-        
+
         Args:
             snapshot (dict): contains the relation ID.
         """
@@ -213,7 +213,7 @@ class GnbIdentityProvides(Object):
         self.framework.observe(charm.on[relation_name].relation_joined, self._on_relation_joined)
 
     def publish_gnb_identity_information(
-        self, relation_id: int, gnb_name: str, tac: int
+            self, relation_id: int, gnb_name: str, tac: int
     ) -> None:
         """Sets gNodeB's name and TAC in the relation data.
 
@@ -223,7 +223,7 @@ class GnbIdentityProvides(Object):
             tac (int): Tracking Area Code.
         """
         if not data_matches_provider_schema(
-            data={"gnb_name": gnb_name, "tac": tac}
+                data={"gnb_name": gnb_name, "tac": tac}
         ):
             raise ValueError(f"Invalid gnb identity data: {gnb_name}, {tac}")
         relation = self.model.get_relation(
@@ -261,7 +261,6 @@ class GnbIdentityAvailableEvent(EventBase):
 
     def restore(self, snapshot: dict) -> None:
         """Restores event data.
-        
         Args:
             snapshot (dict): contains information to be restored.
         """

--- a/lib/charms/sdcore_upf_k8s/v0/fiveg_n4.py
+++ b/lib/charms/sdcore_upf_k8s/v0/fiveg_n4.py
@@ -14,7 +14,7 @@ To get started using the library, you need to fetch the library using `charmcraf
 
 ```shell
 cd some-charm
-charmcraft fetch-lib charms.sdcore_upf.v0.fiveg_n4
+charmcraft fetch-lib charms.sdcore_upf_k8s.v0.fiveg_n4
 ```
 
 Add the following libraries to the charm's `requirements.txt` file:
@@ -26,7 +26,7 @@ Typical usage of this class would look something like:
 
     ```python
     ...
-    from charms.sdcore_upf.v0.fiveg_n4 import N4Provides
+    from charms.sdcore_upf_k8s.v0.fiveg_n4 import N4Provides
     ...
 
     class SomeProviderCharm(CharmBase):
@@ -58,7 +58,7 @@ Typical usage of this class would look something like:
 
     ```python
     ...
-    from charms.sdcore_upf.v0.fiveg_n4 import N4Requires
+    from charms.sdcore_upf_k8s.v0.fiveg_n4 import N4Requires
     ...
 
     class SomeRequirerCharm(CharmBase):
@@ -91,14 +91,14 @@ from ops.framework import EventBase, EventSource, Object
 from pydantic import BaseModel, Field, ValidationError
 
 # The unique Charmhub library identifier, never change it
-LIBID = "bc6261cf77104d4fb3edfd6d4ea63149"
+LIBID = "6c81534a04904d48966ceb7b4f42a850"
 
 # Increment this major API version when introducing breaking changes
 LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 2
+LIBPATCH = 1
 
 PYDEPS = ["pydantic", "pytest-interface-tester"]
 

--- a/lib/charms/sdcore_webui_k8s/v0/sdcore_management.py
+++ b/lib/charms/sdcore_webui_k8s/v0/sdcore_management.py
@@ -14,7 +14,7 @@ to be able to provide or consume the information to access the configuration ser
 From a charm directory, fetch the library using `charmcraft`:
 
 ```shell
-charmcraft fetch-lib charms.sdcore_webui.v0.sdcore_management
+charmcraft fetch-lib charms.sdcore_webui_k8s.v0.sdcore_management
 ```
 
 Add the following libraries to the charm's `requirements.txt` file:
@@ -30,7 +30,7 @@ Example:
 from ops.charm import CharmBase
 from ops.main import main
 
-from charms.sdcore_webui.v0.sdcore_management import (
+from charms.sdcore_webui_k8s.v0.sdcore_management import (
     ManagementUrlAvailable,
     SdcoreManagementRequires,
 )
@@ -66,7 +66,7 @@ Example:
 from ops.charm import CharmBase, RelationJoinedEvent
 from ops.main import main
 
-from charms.sdcore_webui.v0.sdcore_management import (
+from charms.sdcore_webui_k8s.v0.sdcore_management import (
     SdcoreManagementProvides,
 )
 
@@ -105,7 +105,7 @@ from ops.model import Relation
 from pydantic import BaseModel, Field, HttpUrl, ValidationError
 
 # The unique Charmhub library identifier, never change it
-LIBID = "e879ede87229469981725ef404973ee5"
+LIBID = "46698369ff444f10a4e86984c078ee82"
 
 # Increment this major API version when introducing breaking changes
 LIBAPI = 0

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,11 +1,11 @@
-name: sdcore-nms
+name: sdcore-nms-k8s
 
-display-name: SD-Core NMS
+display-name: SD-Core NMS K8s
 summary: A Charmed Operator for SD-Core's NMS.
 description: A Charmed Operator for SD-Core's Network Management System (NMS).
-website: https://charmhub.io/sdcore-nms
-source: https://github.com/canonical/sdcore-nms-operator
-issues: https://github.com/canonical/sdcore-nms-operator/issues
+website: https://charmhub.io/sdcore-nms-k8s
+source: https://github.com/canonical/sdcore-nms-k8s-operator
+issues: https://github.com/canonical/sdcore-nms-k8s-operator/issues
 
 containers:
   nms:

--- a/src/charm.py
+++ b/src/charm.py
@@ -8,9 +8,11 @@ import json
 import logging
 from typing import List, Tuple
 
-from charms.sdcore_gnbsim.v0.fiveg_gnb_identity import GnbIdentityRequires  # type: ignore[import]
-from charms.sdcore_upf.v0.fiveg_n4 import N4Requires  # type: ignore[import]
-from charms.sdcore_webui.v0.sdcore_management import (  # type: ignore[import]
+from charms.sdcore_gnbsim_k8s.v0.fiveg_gnb_identity import (  # type: ignore[import]
+    GnbIdentityRequires,
+)
+from charms.sdcore_upf_k8s.v0.fiveg_n4 import N4Requires  # type: ignore[import]
+from charms.sdcore_webui_k8s.v0.sdcore_management import (  # type: ignore[import]
     SdcoreManagementRequires,
 )
 from charms.traefik_k8s.v2.ingress import IngressPerAppRequirer  # type: ignore[import]

--- a/src/charm.py
+++ b/src/charm.py
@@ -2,7 +2,7 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-"""Charmed operator for the SD-Core Graphical User Interface."""
+"""Charmed operator for the SD-Core Graphical User Interface for K8s."""
 
 import json
 import logging
@@ -31,7 +31,7 @@ UPF_CONFIG_PATH = "/nms/config/upf_config.json"
 
 
 class SDCoreNMSOperatorCharm(CharmBase):
-    """Main class to describe juju event handling for the SD-Core NMS operator."""
+    """Main class to describe juju event handling for the SD-Core NMS operator for K8s."""
 
     def __init__(self, *args):
         super().__init__(*args)

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,6 +4,7 @@ flake8-docstrings
 flake8-builtins
 isort
 juju
+macaroonbakery==1.3.2  # https://protobuf.dev/news/2022-05-06/#python-updates
 mypy
 pep8-naming
 pyproject-flake8


### PR DESCRIPTION
# Description

Add -k8s as a suffix in both github and Charmhub name to follow [TE042](https://docs.google.com/document/d/1R0UzoPr3vvorhbBJYBz-5gZkTCTL2a9_R6xV8K4_i-8/edit).

- Add new fiveg_gnb_identity, fiveg_n4 and sdcore_management libraries
- Pin macaroonbakery to 1.3.2 which installed by juju client indirectly through pytest_operator.
      - The next protobuf version 4.21.0 has the breaking changes with the existing code
      - https://protobuf.dev/news/2022-05-06/#python-updates

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library